### PR TITLE
Modified canopy wind calculation to be continuous.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `href_opt`      | integer for using href_set in namelist (= `0`, default) or array from file (= `1`) |
 | `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) ***\*\*** |
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
-| `rsl_opt`       | user-set option for Roughness SubLayer (RSL) effects above and at canopy top (Uc). `0`: uses a constant lambdars factor only |
+| `rsl_opt`       | user-set option for Roughness SubLayer (RSL) effects above and at canopy top (Uc).(= `0`, default: uses a constant lambdars factor only), (= `1`, default: uses a unified RSL approach from Bonan et al. (2018) and Abolafia-Rosenzweig et al., 2021)   |
 | `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |
 | `dx_opt`        | `0`: Calculation of dx resolution/distance from lon; `1`: user-set dx grid resolution |
 | `dx_set`        | user-set real value of grid resolution (m) only if `dx_opt=1`                      |
@@ -212,6 +212,10 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 ## References
 
 *Further references contained within the source code.*
+
+- Abolafia-Rosenzweig, R., He, C., Burns, S. P., & Chen, F. (2021). Implementation and evaluation of a unified turbulence parameterization throughout the canopy and roughness sublayer in Noah-MP snow simulations. Journal of Advances in Modeling Earth Systems, 13, e2021MS002665. https://doi.org/10.1029/2021MS002665.
+
+- Bonan, G. B., Patton, E. G., Harman, I. N., Oleson, K. W., Finnigan, J. J., Lu, Y., & Burakowski, E. A. (2018). Modeling canopy-induced turbulence in the Earth system: A unified parameterization of turbulent exchange within plant canopies and the roughness sublayer (CLM-ml v0). Geoscientific Model Development, 11, 1467–1496. https://doi.org/10.5194/gmd-11-1467-2018.
 
 - Clifton, O. E., Patton, E. G., Wang, S., Barth, M., Orlando, J., & Schwantes, R. H. (2022). Large eddy simulation for investigating coupled forest canopy and turbulence influences on atmospheric chemistry. Journal of Advances in Modeling Earth Systems, 14, e2022MS003078. https://doi.org/10.1029/2022MS003078
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `ifcanphot`     | logical canopy photolysis option (default: `.FALSE.`)                              |
 | `ifcanbio`      | logical canopy biogenic emissions option (default: `.FALSE.`)                      |
 | `href_opt`      | integer for using href_set in namelist (= `0`, default) or array from file (= `1`) |
-| `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`); Note that if href becomes small and approaches z0 (or as href --> 0), only the sub-canopy wind profile is calculated, recommend href = 10m  |
+| `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) **\*\*** |
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
 | `rsl_opt`       | user-set option for Roughness SubLayer (RSL) effects above and at canopy top (Uc). `0`: uses a constant lambdars factor only |
 | `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |
@@ -202,6 +202,7 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `fch_thresh`    | user-set real value of canopy height  threshold for contiguous canopy (m)          |
 
 **\*\*** If `modres` >> `flameh` then some error in WAF calculation will be incurred.  Suggestion is to use relative fine `modres` (at least <= 0.5 m) compared to average flame heights (e.g., ~ 1.0 m) if WAF is required.
+**\*\*** If `href_set` becomes small and approaches z0 (or as `href_set` --> 0), only the sub-canopy wind profile is calculated, recommend `href_set` = 10 m.  
 
 **Note:** Canopy is parameterized by foliage distribution shape functions and parameters for different vegetation types.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `href_opt`      | integer for using href_set in namelist (= `0`, default) or array from file (= `1`) |
 | `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) ***\*\*** |
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
-| `rsl_opt`       | user-set option for Roughness SubLayer (RSL) effects above and at canopy top (Uc).(= `0`, default: uses a constant lambdars factor only), (= `1`, default: uses a unified RSL approach from Bonan et al. (2018) and Abolafia-Rosenzweig et al., 2021)   |
+| `rsl_opt`       | user-set option for either MOST or unified Roughness SubLayer (RSL) effects above and at canopy top (Uc).(= `0`, default: uses MOST and a constant lambdars factor only), (= `1`, under development: will use a more unified RSL approach from Bonan et al. (2018) and Abolafia-Rosenzweig et al., 2021)   |
 | `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |
 | `dx_opt`        | `0`: Calculation of dx resolution/distance from lon; `1`: user-set dx grid resolution |
 | `dx_set`        | user-set real value of grid resolution (m) only if `dx_opt=1`                      |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `ifcanphot`     | logical canopy photolysis option (default: `.FALSE.`)                              |
 | `ifcanbio`      | logical canopy biogenic emissions option (default: `.FALSE.`)                      |
 | `href_opt`      | integer for using href_set in namelist (= `0`, default) or array from file (= `1`) |
-| `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) ***\*\*** |
+| `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) **\*\*\*** |
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
 | `rsl_opt`       | user-set option for either MOST or unified Roughness SubLayer (RSL) effects above and at canopy top (Uc).(= `0`, default: uses MOST and a constant lambdars factor only), (= `1`, under development: will use a more unified RSL approach from Bonan et al. (2018) and Abolafia-Rosenzweig et al., 2021)   |
 | `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |
@@ -203,7 +203,7 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 
 **\*\*** If `modres` >> `flameh` then some error in WAF calculation will be incurred.  Suggestion is to use relative fine `modres` (at least <= 0.5 m) compared to average flame heights (e.g., ~ 1.0 m) if WAF is required.
 
-***\*\*** If `href_set` becomes small and approaches z0 (or as `href_set` --> 0), only the sub-canopy wind profile is calculated, recommend `href_set` = 10 m.  
+**\*\*\*** If `href_set` becomes small and approaches z0 (or as `href_set` --> 0), only the sub-canopy wind profile is calculated, recommend `href_set` = 10 m.  
 
 **Note:** Canopy is parameterized by foliage distribution shape functions and parameters for different vegetation types.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `ifcanphot`     | logical canopy photolysis option (default: `.FALSE.`)                              |
 | `ifcanbio`      | logical canopy biogenic emissions option (default: `.FALSE.`)                      |
 | `href_opt`      | integer for using href_set in namelist (= `0`, default) or array from file (= `1`) |
-| `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) **\*\*** |
+| `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) ***\*\*** |
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
 | `rsl_opt`       | user-set option for Roughness SubLayer (RSL) effects above and at canopy top (Uc). `0`: uses a constant lambdars factor only |
 | `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |
@@ -202,7 +202,8 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `fch_thresh`    | user-set real value of canopy height  threshold for contiguous canopy (m)          |
 
 **\*\*** If `modres` >> `flameh` then some error in WAF calculation will be incurred.  Suggestion is to use relative fine `modres` (at least <= 0.5 m) compared to average flame heights (e.g., ~ 1.0 m) if WAF is required.
-**\*\*** If `href_set` becomes small and approaches z0 (or as `href_set` --> 0), only the sub-canopy wind profile is calculated, recommend `href_set` = 10 m.  
+
+***\*\*** If `href_set` becomes small and approaches z0 (or as `href_set` --> 0), only the sub-canopy wind profile is calculated, recommend `href_set` = 10 m.  
 
 **Note:** Canopy is parameterized by foliage distribution shape functions and parameters for different vegetation types.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `href_opt`      | integer for using href_set in namelist (= `0`, default) or array from file (= `1`) |
 | `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) |
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
-| `lambdars`      | Value representing influence of roughness sublayer (Massman et al., 2017)          |
+| `rsl_opt`       | user-set option for Roughness SubLayer (RSL) effects above and at canopy top (Uc). `0`: uses a constant lambdars factor only |
+| `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |
 | `dx_opt`        | `0`: Calculation of dx resolution/distance from lon; `1`: user-set dx grid resolution |
 | `dx_set`        | user-set real value of grid resolution (m) only if `dx_opt=1`                      |
 | `flameh_opt`    | `0`: Calculation of flame height from FRP (Byram, 1959); `1`: user-set flameh; `2`: FRP calculation where available (active fires), elsewhere user-set `flameh`; `3`: FlameH override, i.e., only uses fraction of canopy height (`flameh_set` must be <=1.0) as a surrogate for `flameh`; `4`: FRP calculation where available (active fires) and FlameH override elsewhere (same as option 3); `5`: FRP/intensity dependent (i.e., sub-canopy vs. crown fires) calculation where available (active fires) and FlameH override elsewhere (same as option 3). If option 5 is used and crowning is calculated, then the total flame height (i.e., top of canopy=FCH) is used instead of 1/2 flame height. |
@@ -195,7 +196,6 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `pai_set`       | user-set real value of PAI (default: `4.0`; only used if `pai_opt=3`)              |
 | `lu_opt`        | integer for input model land use type (`0`: VIIRS 17 Cat (default) or `1`: MODIS-IGBP 20 Cat (valid LU types 1-10 and 12); input mapped to Massman et al.) |
 | `z0_opt`        | integer (`0`: use model input or `1`: vegtype dependent z0 for first estimate)     |
-| `rsl_opt`       | user-set option to include more explicit stability and Roughness SubLayer (RSL) effects in calculation of wind speed at canopy top (Uc) from reference height. `0`: off; `1`: on |
 | `bio_cce`       | user-set real value of MEGAN biogenic emissions "canopy environment coefficient" used to tune emissions to model inputs/calculations (default: `0.21`, based on Silva et al. 2020) |
 | `lai_thresh`    | user-set real value of LAI threshold for contiguous canopy (m2/m2)                 |
 | `frt_thresh`    | user-set real value of forest fraction threshold for contiguous canopy             |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ https://nacc-in-the-cloud.s3.amazonaws.com/inputs/geo-files/canopy.2022MM01.test
 | `ifcanphot`     | logical canopy photolysis option (default: `.FALSE.`)                              |
 | `ifcanbio`      | logical canopy biogenic emissions option (default: `.FALSE.`)                      |
 | `href_opt`      | integer for using href_set in namelist (= `0`, default) or array from file (= `1`) |
-| `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`) |
+| `href_set`      | user-set real value of reference height above canopy associated with input wind speed (m) (only used if `href_opt=0`); Note that if href becomes small and approaches z0 (or as href --> 0), only the sub-canopy wind profile is calculated, recommend href = 10m  |
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
 | `rsl_opt`       | user-set option for Roughness SubLayer (RSL) effects above and at canopy top (Uc). `0`: uses a constant lambdars factor only |
 | `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |

--- a/input/namelist.canopy
+++ b/input/namelist.canopy
@@ -18,6 +18,7 @@
   href_opt   =  0
   href_set   =  10.0
   z0ghc      =  0.0025
+  rsl_opt    =  0
   lambdars   =  1.25
   dx_opt     =  0
   dx_set     =  12000.0
@@ -28,7 +29,6 @@
   pai_set    =  4.0
   lu_opt     =  1
   z0_opt     =  0
-  rsl_opt    =  1
   bio_cce    =  0.21
   lai_thresh =  0.1
   frt_thresh =  0.1

--- a/src/canopy_calcs.F90
+++ b/src/canopy_calcs.F90
@@ -110,7 +110,7 @@ SUBROUTINE canopy_calcs
                             if (ifcanwind .or. ifcanwaf) then
                                 do k=1, modlays
                                     call canopy_wind(hcmref, zk(k), fafraczInt(k), ubzref, &
-                                        z0ghc, cdrag, pai, hgtref, d_h, zo_h, &
+                                        z0ghc, cdrag, pai, hgtref, d_h, zo_h, molref, &
                                         rsl_opt, lambdars, canBOT(k), canTOP(k), canWIND_3d(i,j,k))
                                 end do
 
@@ -317,7 +317,7 @@ SUBROUTINE canopy_calcs
                         if (ifcanwind .or. ifcanwaf) then
                             do k=1, modlays
                                 call canopy_wind(hcmref, zk(k), fafraczInt(k), ubzref, &
-                                    z0ghc, cdrag, pai, hgtref, d_h, zo_h, &
+                                    z0ghc, cdrag, pai, hgtref, d_h, zo_h, molref, &
                                     rsl_opt, lambdars, canBOT(k), canTOP(k), canWIND(loc, k))
                             end do
 ! ... determine midflamepoint and flame height from user or FRP calculation

--- a/src/canopy_calcs.F90
+++ b/src/canopy_calcs.F90
@@ -8,14 +8,14 @@ SUBROUTINE canopy_calcs
 !-------------------------------------------------------------------------------
 
     use canopy_const_mod, ONLY: rk      !constants for canopy models
-    use canopy_coord_mod   !main canopy coordinate descriptions
-    use canopy_canopts_mod !main canopy option descriptions
-    use canopy_canmet_mod  !main canopy met/sfc input descriptions
-    use canopy_canvars_mod !main canopy variables descriptions
-    use canopy_utils_mod   !main canopy utilities
-    use canopy_dxcalc_mod  !main canopy dx calculation
-    use canopy_profile_mod !main canopy foliage profile routines
-    use canopy_wind_mod    !main canopy components/submodules
+    use canopy_coord_mod      !main canopy coordinate descriptions
+    use canopy_canopts_mod    !main canopy option descriptions
+    use canopy_canmet_mod     !main canopy met/sfc input descriptions
+    use canopy_canvars_mod    !main canopy variables descriptions
+    use canopy_utils_mod      !main canopy utilities
+    use canopy_dxcalc_mod     !main canopy dx calculation
+    use canopy_profile_mod    !main canopy foliage profile routines
+    use canopy_wind_mod       !main canopy wind components
     use canopy_waf_mod
     use canopy_phot_mod
     use canopy_eddy_mod
@@ -108,11 +108,16 @@ SUBROUTINE canopy_calcs
 ! ... user option to calculate in-canopy wind speeds at height z and midflame WAF
 
                             if (ifcanwind .or. ifcanwaf) then
-                                do k=1, modlays
-                                    call canopy_wind(hcmref, zk(k), fafraczInt(k), ubzref, &
-                                        z0ghc, cdrag, pai, hgtref, d_h, zo_h, molref, &
-                                        rsl_opt, lambdars, canBOT(k), canTOP(k), canWIND_3d(i,j,k))
-                                end do
+                                if (rsl_opt .eq. 0) then
+                                    do k=1, modlays
+                                        call canopy_wind_most(hcmref, zk(k), fafraczInt(k), ubzref, &
+                                            z0ghc, cdrag, pai, hgtref, d_h, zo_h, &
+                                            lambdars, canBOT(k), canTOP(k), canWIND_3d(i,j,k))
+                                    end do
+                                else
+                                    write(*,*) 'wrong namelist option = ', rsl_opt, 'only option = 0 right now'
+                                    call exit(2)
+                                end if
 
 ! ... determine midflamepoint and flame height from user or FRP calculation
                                 call canopy_flameh(flameh_opt, flameh_set, dx_2d(i,j), modres, &
@@ -315,11 +320,17 @@ SUBROUTINE canopy_calcs
 ! ... user option to calculate in-canopy wind speeds at height z and midflame WAF
 
                         if (ifcanwind .or. ifcanwaf) then
-                            do k=1, modlays
-                                call canopy_wind(hcmref, zk(k), fafraczInt(k), ubzref, &
-                                    z0ghc, cdrag, pai, hgtref, d_h, zo_h, molref, &
-                                    rsl_opt, lambdars, canBOT(k), canTOP(k), canWIND(loc, k))
-                            end do
+                            if (rsl_opt .eq. 0) then
+                                do k=1, modlays
+                                    call canopy_wind_most(hcmref, zk(k), fafraczInt(k), ubzref, &
+                                        z0ghc, cdrag, pai, hgtref, d_h, zo_h, &
+                                        lambdars, canBOT(k), canTOP(k), canWIND(loc,k))
+                                end do
+                            else
+                                write(*,*) 'wrong namelist option = ', rsl_opt, 'only option = 0 right now'
+                                call exit(2)
+                            end if
+
 ! ... determine midflamepoint and flame height from user or FRP calculation
                             call canopy_flameh(flameh_opt, flameh_set, dx(loc), modres, &
                                 frpref, frp_fac, hcmref, midflamepoint, flameh(loc))

--- a/src/canopy_calcs.F90
+++ b/src/canopy_calcs.F90
@@ -110,7 +110,7 @@ SUBROUTINE canopy_calcs
                             if (ifcanwind .or. ifcanwaf) then
                                 do k=1, modlays
                                     call canopy_wind(hcmref, zk(k), fafraczInt(k), ubzref, &
-                                        z0ghc, cdrag, pai, hgtref, d_h, zo_h, molref, &
+                                        z0ghc, cdrag, pai, hgtref, d_h, zo_h, &
                                         rsl_opt, lambdars, canBOT(k), canTOP(k), canWIND_3d(i,j,k))
                                 end do
 
@@ -317,7 +317,7 @@ SUBROUTINE canopy_calcs
                         if (ifcanwind .or. ifcanwaf) then
                             do k=1, modlays
                                 call canopy_wind(hcmref, zk(k), fafraczInt(k), ubzref, &
-                                    z0ghc, cdrag, pai, hgtref, d_h, zo_h, molref, &
+                                    z0ghc, cdrag, pai, hgtref, d_h, zo_h, &
                                     rsl_opt, lambdars, canBOT(k), canTOP(k), canWIND(loc, k))
                             end do
 ! ... determine midflamepoint and flame height from user or FRP calculation

--- a/src/canopy_waf_mod.F90
+++ b/src/canopy_waf_mod.F90
@@ -154,7 +154,7 @@ contains
 ! (2017)  W.J. Massman, J.M. Forthofer, M.A. Finney.  https://doi.org/10.1139/cjfr-2016-0354
 
         if (HREF <= 0.0) then
-            write(*,*) "critical problem: HREF <= 0, WAF calculation not accurate and thus is reset to 1"
+            write(*,*) "warning: HREF <= 0, WAF calculation not accurate and thus is reset to 1"
             waf = 1.0
         else
 

--- a/src/canopy_wind_mod.F90
+++ b/src/canopy_wind_mod.F90
@@ -5,8 +5,8 @@ module canopy_wind_mod
 contains
 
 !:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-    SUBROUTINE CANOPY_WIND( HCM, ZK, FAFRACK, UBZREF, Z0GHC, &
-        CDRAG, PAI, HREF, D_H, ZO_H, MOL, RSL_OPT, LAMBDARS, &
+    SUBROUTINE CANOPY_WIND_MOST( HCM, ZK, FAFRACK, UBZREF, Z0GHC, &
+        CDRAG, PAI, HREF, D_H, ZO_H, LAMBDARS, &
         CANBOT_OUT, CANTOP_OUT, CANWIND )
 
 !-----------------------------------------------------------------------
@@ -21,6 +21,7 @@ contains
 
 ! Revision History:
 !     Prototype 06/22 by PCC, based on Massman et al. (2017) algorithms
+!     below the canopy and use of MOST above canopy.
 !     Jun 2022 P.C. Campbell: Initial standalone canopy wind model
 !-----------------------------------------------------------------------
 !-----------------------------------------------------------------------
@@ -40,8 +41,8 @@ contains
         REAL(RK),    INTENT( IN )  :: HREF             ! Reference Height above canopy associated with ref wind speed  (m)
         REAL(RK),    INTENT( IN )  :: D_H              ! Zero plane displacement heights (nondimensional)
         REAL(RK),    INTENT( IN )  :: ZO_H             ! Surface (soil+veg) roughness lengths (nondimensional)
-        REAL(RK),    INTENT( IN )  :: MOL              ! Model input Monin-Obukhov Length
-        INTEGER,     INTENT( IN )  :: RSL_OPT          ! RSL option used in model (default = 0, LAMBDARS effect only)
+!        REAL(RK),    INTENT( IN )  :: MOL              ! Model input Monin-Obukhov Length
+!        INTEGER,     INTENT( IN )  :: RSL_OPT          ! RSL option used in model (default = 0, LAMBDARS effect only)
         REAL(RK),    INTENT( OUT ) :: CANBOT_OUT       ! Canopy bottom wind reduction factor = canbot (nondimensional)
         REAL(RK),    INTENT( OUT ) :: CANTOP_OUT       ! Canopy top wind reduction factor = cantop    (nondimensional)
         REAL(RK),    INTENT( OUT ) :: CANWIND          ! Mean canopy wind speed at current z (m/s)
@@ -55,18 +56,18 @@ contains
         real(rk)                   :: canbot           ! Logarithmic wind speed that is dominant near the ground (nondimensional)
         real(rk)                   :: cantop           ! Hyperbolic cosine wind speed that is dominant near the top of canopy (nondimensional)
         real(rk)                   :: zpd              ! Zero plane displacement heights MOST  (m)
-        real(rk)                   :: zpd_rsl          ! Zero plane displacement heights RSL   (m)
+!        real(rk)                   :: zpd_rsl          ! Zero plane displacement heights RSL   (m)
         real(rk)                   :: z0m              ! Surface (soil+veg) roughness lengths with Massman LAMBDARS (m)
         real(rk)                   :: uc               ! Wind directly at canopy top (m/s)
-        real(rk)                   :: cbeta            ! Term used to calculated beta_n for sparse canopies
-        real(rk)                   :: beta, beta_n     ! Ratio of u* to wind speed at canopy height
-        real(rk)                   :: beta1, beta2     ! Terms used in calculating beta above
-        real(rk)                   :: can_length       ! Canopy length scale (Lc= HCM/CDRAG*PAI) (m)
-        real(rk)                   :: mix_length       ! Mixing length scale (m)
-        real(rk)                   :: zref             ! Reference height above canopy top (m)
-        real(rk)                   :: phim, phim_rsl   ! Momentum terms used in for MOST and RSL adjustments
-        real(rk)                   :: c1, c2, xi       ! RSL terms used to adjust MOST for canopy-induced turbulence
-        real(rk)                   :: den1, den2, den3 !Denominator terms in RSL unified U* calculation
+!        real(rk)                   :: cbeta            ! Term used to calculated beta_n for sparse canopies
+!        real(rk)                   :: beta, beta_n     ! Ratio of u* to wind speed at canopy height
+!        real(rk)                   :: beta1, beta2     ! Terms used in calculating beta above
+!        real(rk)                   :: can_length       ! Canopy length scale (Lc= HCM/CDRAG*PAI) (m)
+!        real(rk)                   :: mix_length       ! Mixing length scale (m)
+!        real(rk)                   :: zref             ! Reference height above canopy top (m)
+!        real(rk)                   :: phim, phim_rsl   ! Momentum terms used in for MOST and RSL adjustments
+!        real(rk)                   :: c1, c2, xi       ! RSL terms used to adjust MOST for canopy-induced turbulence
+!        real(rk)                   :: den1, den2, den3 !Denominator terms in RSL unified U* calculation
 
 ! Citation:
 ! An improved canopy wind model for predicting wind adjustment factors and wildland fire behavior
@@ -90,111 +91,111 @@ contains
             call exit(1)
         end if
 
-        if (RSL_OPT .eq. 0) then !Massman approach with MOST + LAMBDARS tuned RSL factor/effects
+        !       if (RSL_OPT .eq. 0) then !Massman approach with MOST + LAMBDARS tuned RSL factor/effects
 
-            if (HREF > z0m) then ! input wind speed reference height is > roughness length
-                uc = UBZREF*log(LAMBDARS*(HCM-zpd+z0m)/z0m)/log(HREF/z0m)  !MOST From NoahMP (M. Barlarge) with user RSL influence term (LAMBDARS)
-            else                 ! reference height is <= roughness length--at canopy top (used for observation comparison)
-                uc = UBZREF
-            end if
-
-            !Some checks on Uc calculation
-            if (uc > UBZREF) then !reference height too small and close to roughness length
-                uc = UBZREF
-            end if
-
-            if (uc <= 0.0) then
-                write(*,*)  'Uc cannot be <= 0 at  ',uc , ' in canopy_wind calc...exiting'
-                call exit(1)
-            end if
-
-            !Calculate U* from Massman 1997 (https://doi.org/10.1023/A:1000234813011)
-            ustrmod = uc*(0.38_rk - (0.38_rk + (vonk/log(Z0GHC)))*exp(-1.0_rk*(15.0_rk*drag)))
-
-        else if (RSL_OPT .eq. 1) then  !Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-            cbeta = vonk**2.0_rk*(log((HCM + 0.01_rk)/0.01_rk))**(-2.0_rk) !dense and sparse canopies
-            beta_n = (cbeta + (0.3_rk*PAI))**(0.5) !beta for neutral conditions, dense and sparse canopies
-            if (beta_n .gt. 0.35_rk) then      !constrained to be less than 0.35
-                beta_n = 0.35_rk
-            end if
-
-            can_length = HCM/drag          !canopy length scale (Lc)
-            zref = HREF + HCM              !reference height z above canopy top
-
-            !Check stability for β calculation
-            IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
-                beta1 = -1.0_rk*((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)
-                beta2 = sqrt( (((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)**2.0_rk) + (4.0_rk*(beta_n**4.0_rk)) )
-                beta = sqrt( 0.5_rk * (beta1 + beta2) )
-            ELSE IF ( MOL .GT.  0.0 ) THEN !STABLE to VERY STABLE
-                beta1 = -1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
-                    4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
-                    27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (1.0_rk/3.0_rk)) * &
-                    (MOL/(15.0_rk*can_length))
-                beta2 = +1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
-                    4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
-                    27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (-1.0_rk/3.0_rk))
-                beta = (beta1 + beta2)
-            ELSE                          !NEUTRAL
-                beta = beta_n
-            END IF
-
-            !The solution for β is constrained between 0.2 and 0.5 (Bonan et al., 2018).
-            if (beta .lt. 0.2) then
-                beta = 0.2
-            else if (beta .gt. 0.5) then
-                beta = 0.5
-            end if
-
-            !Mixing length (lm)
-            mix_length=2.0_rk*(beta**(3.0_rk))*can_length
-!            print*, 'mix_length=',mix_length
-
-!recalculate the zero plane displacement height for Unified RSL if dense or sparse canopy
-!dense+sparse
-            zpd_rsl = HCM - ((beta**2.0_rk) * can_length) * &
-                (1.0_rk - exp(-1.0_rk*((0.25_rk*PAI)/(beta**2.0_rk))))
-
-!            print*, 'can_length=',can_length, 'zpd=',zpd, 'zpd_rsl=',zpd_rsl
-!            zpd_rsl=zpd
-
-            !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-            IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
-                phim = (1.0_rk - (16.0_rk*((zref - zpd_rsl)/MOL)))**(-0.25_rk)
-            ELSE                           !NEUTRAL-STABLE
-                phim = (1.0_rk + (5.0_rk*((zref - zpd_rsl)/MOL)))
-            END IF
-
-            c2 = 0.5_rk
-            c1 = (1.0_rk - (vonk/(2.0_rk*beta))*(1.0_rk/phim)*((HCM - zpd_rsl)/MOL))*exp(c2/2.0_rk)
-            xi = ((zref - zpd_rsl)*beta)/mix_length
-            phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
-            den1 = (zref-zpd_rsl)/(HCM-zpd_rsl)
-            den2 = (zref-zpd_rsl)/MOL
-            den3 = (HCM-zpd_rsl)/MOL
-
-            ustrmod = (UBZREF*vonk)/(log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*zref) - (phim_rsl*HCM) +  &
-                (vonk/beta))
-            if (HREF > z0m) then ! input wind speed reference height is > roughness length
-                uc = ustrmod/beta ! (Rosenzweig et al., 2021)
-            else
-                uc = UBZREF
-            end if
-
-            !Some checks on Uc calculation
-            if (uc > UBZREF) then !reference height too small and close to roughness length
-                uc = UBZREF
-            end if
-
-            if (uc <= 0.0) then
-                write(*,*)  'Uc cannot be <= 0 at  ',uc , ' in canopy_wind calc...exiting'
-                call exit(1)
-            end if
-
-        else
-            write(*,*) 'wrong namelist option = ', RSL_OPT, 'only options = 0 or 1 is available right now'
-            call exit(2)
+        if (HREF > z0m) then ! input wind speed reference height is > roughness length
+            uc = UBZREF*log(LAMBDARS*(HCM-zpd+z0m)/z0m)/log(HREF/z0m)  !MOST From NoahMP (M. Barlarge) with user RSL influence term (LAMBDARS)
+        else                 ! reference height is <= roughness length--at canopy top (used for observation comparison)
+            uc = UBZREF
         end if
+
+        !Some checks on Uc calculation
+        if (uc > UBZREF) then !reference height too small and close to roughness length
+            uc = UBZREF
+        end if
+
+        if (uc <= 0.0) then
+            write(*,*)  'Uc cannot be <= 0 at  ',uc , ' in canopy_wind calc...exiting'
+            call exit(1)
+        end if
+
+        !Calculate U* from Massman 1997 (https://doi.org/10.1023/A:1000234813011)
+        ustrmod = uc*(0.38_rk - (0.38_rk + (vonk/log(Z0GHC)))*exp(-1.0_rk*(15.0_rk*drag)))
+
+!        else if (RSL_OPT .eq. 1) then  !Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
+!            cbeta = vonk**2.0_rk*(log((HCM + 0.01_rk)/0.01_rk))**(-2.0_rk) !dense and sparse canopies
+!            beta_n = (cbeta + (0.3_rk*PAI))**(0.5) !beta for neutral conditions, dense and sparse canopies
+!            if (beta_n .gt. 0.35_rk) then      !constrained to be less than 0.35
+!                beta_n = 0.35_rk
+!            end if
+!
+!            can_length = HCM/drag          !canopy length scale (Lc)
+!            zref = HREF + HCM              !reference height z above canopy top
+!
+!            !Check stability for β calculation
+!            IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
+!                beta1 = -1.0_rk*((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)
+!                beta2 = sqrt( (((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)**2.0_rk) + (4.0_rk*(beta_n**4.0_rk)) )
+!                beta = sqrt( 0.5_rk * (beta1 + beta2) )
+!            ELSE IF ( MOL .GT.  0.0 ) THEN !STABLE to VERY STABLE
+!                beta1 = -1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
+!                    4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
+!                    27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (1.0_rk/3.0_rk)) * &
+!                    (MOL/(15.0_rk*can_length))
+!                beta2 = +1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
+!                    4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
+!                    27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (-1.0_rk/3.0_rk))
+!                beta = (beta1 + beta2)
+!            ELSE                          !NEUTRAL
+!                beta = beta_n
+!            END IF
+!
+!            !The solution for β is constrained between 0.2 and 0.5 (Bonan et al., 2018).
+!            if (beta .lt. 0.2) then
+!                beta = 0.2
+!            else if (beta .gt. 0.5) then
+!                beta = 0.5
+!            end if
+!
+!            !Mixing length (lm)
+!            mix_length=2.0_rk*(beta**(3.0_rk))*can_length
+!!            print*, 'mix_length=',mix_length
+!
+!!recalculate the zero plane displacement height for Unified RSL if dense or sparse canopy
+!!dense+sparse
+!            zpd_rsl = HCM - ((beta**2.0_rk) * can_length) * &
+!                (1.0_rk - exp(-1.0_rk*((0.25_rk*PAI)/(beta**2.0_rk))))
+!
+!!            print*, 'can_length=',can_length, 'zpd=',zpd, 'zpd_rsl=',zpd_rsl
+!!            zpd_rsl=zpd
+!
+!            !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
+!            IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
+!                phim = (1.0_rk - (16.0_rk*((zref - zpd_rsl)/MOL)))**(-0.25_rk)
+!            ELSE                           !NEUTRAL-STABLE
+!                phim = (1.0_rk + (5.0_rk*((zref - zpd_rsl)/MOL)))
+!            END IF
+!
+!            c2 = 0.5_rk
+!            c1 = (1.0_rk - (vonk/(2.0_rk*beta))*(1.0_rk/phim)*((HCM - zpd_rsl)/MOL))*exp(c2/2.0_rk)
+!            xi = ((zref - zpd_rsl)*beta)/mix_length
+!            phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
+!            den1 = (zref-zpd_rsl)/(HCM-zpd_rsl)
+!            den2 = (zref-zpd_rsl)/MOL
+!            den3 = (HCM-zpd_rsl)/MOL
+!
+!            ustrmod = (UBZREF*vonk)/(log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*zref) - (phim_rsl*HCM) +  &
+!                (vonk/beta))
+!            if (HREF > z0m) then ! input wind speed reference height is > roughness length
+!                uc = ustrmod/beta ! (Rosenzweig et al., 2021)
+!            else
+!                uc = UBZREF
+!            end if
+!
+!            !Some checks on Uc calculation
+!            if (uc > UBZREF) then !reference height too small and close to roughness length
+!                uc = UBZREF
+!            end if
+!
+!            if (uc <= 0.0) then
+!                write(*,*)  'Uc cannot be <= 0 at  ',uc , ' in canopy_wind calc...exiting'
+!                call exit(1)
+!            end if
+!
+!        else
+!            write(*,*) 'wrong namelist option = ', RSL_OPT, 'only options = 0 or 1 is available right now'
+!            call exit(2)
+!        end if
 
 !Calculate in-canopy parameters that dominate near top region of canopy (Massman et al., 2017)
         cstress = (2.0_rk*(ustrmod**2.0_rk))/(uc**2.0_rk)
@@ -217,43 +218,43 @@ contains
         if (ZK <= HCM) then       !at or below canopy top --> Massman in-canopy profile
             CANWIND = uc*canbot*cantop
         else                      !above canopy top       --> MOST or RSL profile
-            if (RSL_OPT .eq. 0) then
-                if (uc < UBZREF) then !reference height is not small compared to z0m
-                    CANWIND = UBZREF*log(LAMBDARS*(ZK-zpd+z0m)/z0m)/log(HREF/z0m)
-                else                  !cannot calcualate above canopy wind, set constant to UBZREF
-                    CANWIND = UBZREF
-                end if
-            else if (RSL_OPT .eq. 1) then
-                if (uc < UBZREF) then !reference height is not small compared to z0m
-                    !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-                    IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
-                        phim = (1.0_rk - (16.0_rk*((ZK - zpd_rsl)/MOL)))**(-0.25_rk)
-                    ELSE                           !NEUTRAL-STABLE
-                        phim = (1.0_rk + (5.0_rk*((ZK - zpd_rsl)/MOL)))
-                    END IF
-
-                    c2 = 0.5_rk
-                    c1 = (1.0_rk - (vonk/(2.0_rk*beta))*(1.0_rk/phim)*((HCM - zpd_rsl)/MOL))*exp(c2/2.0_rk)
-                    xi = ((ZK - zpd_rsl)*beta)/mix_length
-                    phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
-                    den1 = (ZK-zpd_rsl)/(HCM-zpd_rsl)
-                    den2 = (ZK-zpd_rsl)/MOL
-!                    den2 = (ZK-zpd_rsl)/(mix_length*beta)
-                    den3 = (HCM-zpd_rsl)/MOL
-!                    den3 = (HCM-zpd_rsl)/(mix_length*beta)
-
-                    CANWIND = (ustrmod / vonk) * &
-                        (log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*den2) - (phim_rsl*den3) +  &
-                        (vonk/beta))
-                else                  !cannot calcualate above canopy wind, set constant to UBZREF
-                    CANWIND = UBZREF
-                end if
-            else
-                write(*,*) 'wrong namelist option = ', RSL_OPT, 'only options = 0 or 1 is available right now'
-                call exit(2)
-            end if !RSL Opt
+!            if (RSL_OPT .eq. 0) then
+            if (uc < UBZREF) then !reference height is not small compared to z0m
+                CANWIND = UBZREF*log(LAMBDARS*(ZK-zpd+z0m)/z0m)/log(HREF/z0m)
+            else                  !cannot calcualate above canopy wind, set constant to UBZREF
+                CANWIND = UBZREF
+            end if
+!            else if (RSL_OPT .eq. 1) then
+!                if (uc < UBZREF) then !reference height is not small compared to z0m
+!                    !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
+!                    IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
+!                        phim = (1.0_rk - (16.0_rk*((ZK - zpd_rsl)/MOL)))**(-0.25_rk)
+!                    ELSE                           !NEUTRAL-STABLE
+!                        phim = (1.0_rk + (5.0_rk*((ZK - zpd_rsl)/MOL)))
+!                    END IF
+!
+!                    c2 = 0.5_rk
+!                    c1 = (1.0_rk - (vonk/(2.0_rk*beta))*(1.0_rk/phim)*((HCM - zpd_rsl)/MOL))*exp(c2/2.0_rk)
+!                    xi = ((ZK - zpd_rsl)*beta)/mix_length
+!                    phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
+!                    den1 = (ZK-zpd_rsl)/(HCM-zpd_rsl)
+!                    den2 = (ZK-zpd_rsl)/MOL
+!!                    den2 = (ZK-zpd_rsl)/(mix_length*beta)
+!                    den3 = (HCM-zpd_rsl)/MOL
+!!                    den3 = (HCM-zpd_rsl)/(mix_length*beta)
+!
+!                    CANWIND = (ustrmod / vonk) * &
+!                        (log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*den2) - (phim_rsl*den3) +  &
+!                        (vonk/beta))
+!                else                  !cannot calcualate above canopy wind, set constant to UBZREF
+!                    CANWIND = UBZREF
+!                end if
+!            else
+!                write(*,*) 'wrong namelist option = ', RSL_OPT, 'only options = 0 or 1 is available right now'
+!                call exit(2)
+!            end if !RSL Opt
         end if !Above or below canopy
 
-    END SUBROUTINE CANOPY_WIND
+    END SUBROUTINE CANOPY_WIND_MOST
 
 end module canopy_wind_mod

--- a/src/canopy_wind_mod.F90
+++ b/src/canopy_wind_mod.F90
@@ -6,7 +6,7 @@ contains
 
 !:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
     SUBROUTINE CANOPY_WIND( HCM, ZK, FAFRACK, UBZREF, Z0GHC, &
-        CDRAG, PAI, HREF, D_H, ZO_H, MOL, RSL_OPT, LAMBDARS, &
+        CDRAG, PAI, HREF, D_H, ZO_H, RSL_OPT, LAMBDARS, &
         CANBOT_OUT, CANTOP_OUT, CANWIND )
 
 !-----------------------------------------------------------------------
@@ -40,8 +40,8 @@ contains
         REAL(RK),    INTENT( IN )  :: HREF            ! Reference Height above canopy associated with ref wind speed  (m)
         REAL(RK),    INTENT( IN )  :: D_H             ! Zero plane displacement heights (nondimensional)
         REAL(RK),    INTENT( IN )  :: ZO_H            ! Surface (soil+veg) roughness lengths (nondimensional)
-        REAL(RK),    INTENT( IN )  :: MOL             ! Model input Monin-Obukhov Length
-        INTEGER,     INTENT( IN )  :: RSL_OPT         ! RSL option used in model from Rosenzweig et al. 2021 (default = 0, off)
+!        REAL(RK),    INTENT( IN )  :: MOL             ! Model input Monin-Obukhov Length
+        INTEGER,     INTENT( IN )  :: RSL_OPT         ! RSL option used in model (default = 0, LAMBDARS effect only)
         REAL(RK),    INTENT( OUT ) :: CANBOT_OUT      ! Canopy bottom wind reduction factor = canbot (nondimensional)
         REAL(RK),    INTENT( OUT ) :: CANTOP_OUT      ! Canopy top wind reduction factor = cantop    (nondimensional)
         REAL(RK),    INTENT( OUT ) :: CANWIND         ! Mean canopy wind speed at current z (m/s)
@@ -57,9 +57,9 @@ contains
         real(rk)                   :: zpd             ! Zero plane displacement heights (m)
         real(rk)                   :: z0m             ! Surface (soil+veg) roughness lengths (m)
         real(rk)                   :: uc              ! Wind directly at canopy top (m/s)
-        real(rk)                   :: beta, beta_n    ! Ratio of u* to wind speed at canopy height
-        real(rk)                   :: beta1, beta2    ! Terms used in calculating beta above
-        real(rk)                   :: can_length      ! Canopy length scale (= HCM/CDRAG*PAI)
+!        real(rk)                   :: beta, beta_n    ! Ratio of u* to wind speed at canopy height
+!        real(rk)                   :: beta1, beta2    ! Terms used in calculating beta above
+!        real(rk)                   :: can_length      ! Canopy length scale (= HCM/CDRAG*PAI)
 
 ! Citation:
 ! An improved canopy wind model for predicting wind adjustment factors and wildland fire behavior
@@ -67,78 +67,70 @@ contains
         zkhcm = ZK/HCM
         z0g = Z0GHC*HCM
 
-        ! Nondimensional canopy wind speed term that dominates near the ground:
-        if (ZK >= z0g .and. ZK <= HCM) then
-            canbot = log(zkhcm/Z0GHC)/log(1.0_rk/Z0GHC)
-        else if (ZK >= 0 .and. ZK <= z0g) then
-            canbot = 0.0  !No-slip condition at surface (u=0 at z=0)
-        else
-            canbot = 1  ! should be zk > hcm
-        end if
-
-        CANBOT_OUT = canbot
         ! Nondimensional canopy wind speed term that dominates near the top of the canopy:
         ! Assume the drag area distribution over depth of canopy can be approx. p1=0 (no shelter factor) and d1=0
         ! (no drag coefficient relation to wind speed) -- thus no integration then required in Eq. (4) of Massman et al.
         drag    = CDRAG*PAI
 
-        !first adjust reference wind down to canopy top wind using MOST (with no RSL effects)
         zpd = D_H*HCM  !zero-plane displacement height (not scaled to HCM)
         z0m = ZO_H*HCM !aerodynamic roughness length (not scaled to HCM)
+
+        !first adjust reference wind down to canopy top to get u* from Massman closure equations (necessary)
+
         if((HCM-zpd) <= 0.) then
             write(*,*) "critical problem: hcan <= zpd"
             call exit(1)
         end if
 
         if (HREF > z0m) then ! input wind speed reference height is > roughness length
-            uc = UBZREF*log((HCM-zpd+z0m)/z0m)/log(HREF/z0m)  !MOST
-        else                 ! reference height is <= roughness length--at canopy top
+            uc = UBZREF*log(LAMBDARS*(HCM-zpd+z0m)/z0m)/log(HREF/z0m)  !MOST From NoahMP (M. Barlarge) with user RSL influence term (LAMBDARS)
+        else                 ! reference height is <= roughness length--at canopy top (used for observation comparison)
             uc = UBZREF
         end if
 
         !calculate U* from Massman 1997 (https://doi.org/10.1023/A:1000234813011)
         ustrmod = uc*(0.38_rk - (0.38_rk + (vonk/log(Z0GHC)))*exp(-1.0_rk*(15.0_rk*drag)))
 
-        if (HREF > z0m) then ! input wind speed reference height is > roughness length
-            if (RSL_OPT .eq. 0) then       !MOST From NoahMP (M. Barlarge) with user RSL influence term (LAMBDARS)
-                uc = UBZREF*log(LAMBDARS*(HCM-zpd+z0m)/z0m)/log(HREF/z0m) !Recalculate Uc with LAMBDARS
-            else if (RSL_OPT .eq. 1) then  !Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-                beta_n = 0.35_rk               !beta for neutral conditions
-                can_length = HCM/drag          !canopy length scale
-
-                !Check stability for β calculation
-                IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
-                    beta1 = -1.0_rk*((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)
-                    beta2 = sqrt( (((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)**2.0_rk) + (4.0_rk*(beta_n**4.0_rk)) )
-                    beta = sqrt( 0.5_rk * (beta1 + beta2) )
-                ELSE IF ( MOL .GT.  0.0 ) THEN !STABLE to VERY STABLE
-                    beta1 = -1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
-                        4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
-                        27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (1.0_rk/3.0_rk)) * &
-                        (MOL/(15.0_rk*can_length))
-                    beta2 = +1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
-                        4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
-                        27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (-1.0_rk/3.0_rk))
-                    beta = (beta1 + beta2)
-                ELSE                          !NEUTRAL
-                    beta = beta_n
-                END IF
-
-                !The solution for β is constrained between 0.2 and 0.5 (Bonan et al., 2018).
-                if (beta .lt. 0.2) then
-                    beta = 0.2
-                else if (beta .gt. 0.5) then
-                    beta = 0.5
-                end if
-
-                uc = ustrmod/beta
-            else
-                write(*,*) 'wrong namelist option', RSL_OPT, 'only 0 (MOST) or 1 (RSL) available'
-                call exit(2)
-            end if
-        else
-            uc = UBZREF
+!        if (HREF > z0m) then ! input wind speed reference height is > roughness length
+        if (RSL_OPT .ne. 0) then       !MOST From NoahMP (M. Barlarge) with user RSL influence term (LAMBDARS)
+!                uc = UBZREF*log(LAMBDARS*(HCM-zpd+z0m)/z0m)/log(HREF/z0m) !Recalculate Uc with LAMBDARS
+!            else if (RSL_OPT .eq. 1) then  !Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
+!                beta_n = 0.35_rk               !beta for neutral conditions
+!                can_length = HCM/drag          !canopy length scale
+!
+!                !Check stability for β calculation
+!                IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
+!                    beta1 = -1.0_rk*((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)
+!                    beta2 = sqrt( (((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)**2.0_rk) + (4.0_rk*(beta_n**4.0_rk)) )
+!                    beta = sqrt( 0.5_rk * (beta1 + beta2) )
+!                ELSE IF ( MOL .GT.  0.0 ) THEN !STABLE to VERY STABLE
+!                    beta1 = -1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
+!                        4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
+!                        27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (1.0_rk/3.0_rk)) * &
+!                        (MOL/(15.0_rk*can_length))
+!                    beta2 = +1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
+!                        4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
+!                        27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (-1.0_rk/3.0_rk))
+!                    beta = (beta1 + beta2)
+!                ELSE                          !NEUTRAL
+!                    beta = beta_n
+!                END IF
+!
+!                !The solution for β is constrained between 0.2 and 0.5 (Bonan et al., 2018).
+!                if (beta .lt. 0.2) then
+!                    beta = 0.2
+!                else if (beta .gt. 0.5) then
+!                    beta = 0.5
+!                end if
+!
+!                uc = ustrmod/beta
+!            else
+            write(*,*) 'wrong namelist option = ', RSL_OPT, 'only option = 0 (MOST*LAMBDARS) is available right now'
+            call exit(2)
         end if
+!        else
+!            uc = UBZREF
+!        end if
 
         if (uc > UBZREF) then !reference height still small and close to roughness length
             uc = UBZREF
@@ -149,16 +141,26 @@ contains
             call exit(1)
         end if
 
-        !Calculate remaining in-canopy parameters (Massman et al., 2017)
+        !Calculate in-canopy parameters that dominate near top region of canopy (Massman et al., 2017)
         cstress = (2.0_rk*(ustrmod**2.0_rk))/(uc**2.0_rk)
         nrat   =  drag/cstress
         cantop = cosh(nrat*FAFRACK)/cosh(nrat)
         CANTOP_out = cantop
 
+        !Calculate in-canopy parameters that dominate near the ground:
+        if (ZK >= z0g .and. ZK <= HCM) then
+            canbot = log(zkhcm/Z0GHC)/log(1.0_rk/Z0GHC)
+        else if (ZK >= 0 .and. ZK <= z0g) then
+            canbot = 0.0  !No-slip condition at surface (u=0 at z=0)
+        else
+            canbot = 1  ! should be zk > hcm
+        end if
+        CANBOT_OUT = canbot
+
         if (ZK <= HCM) then       !at or below canopy top --> modify uc winds
             CANWIND = uc*canbot*cantop
         else
-            CANWIND = UBZREF       !above canopy top constant and equal to reference winds
+            CANWIND = UBZREF*log(LAMBDARS*(ZK-zpd+z0m)/z0m)/log(HREF/z0m)       !above canopy top = logarithmic profile
         end if
 
     END SUBROUTINE CANOPY_WIND

--- a/src/canopy_wind_mod.F90
+++ b/src/canopy_wind_mod.F90
@@ -6,7 +6,7 @@ contains
 
 !:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
     SUBROUTINE CANOPY_WIND( HCM, ZK, FAFRACK, UBZREF, Z0GHC, &
-        CDRAG, PAI, HREF, D_H, ZO_H, RSL_OPT, LAMBDARS, &
+        CDRAG, PAI, HREF, D_H, ZO_H, MOL, RSL_OPT, LAMBDARS, &
         CANBOT_OUT, CANTOP_OUT, CANWIND )
 
 !-----------------------------------------------------------------------
@@ -28,38 +28,45 @@ contains
 
 ! Arguments:
 !       IN/OUT
-        REAL(RK),    INTENT( IN )  :: HCM             ! Height of canopy top (m)
-        REAL(RK),    INTENT( IN )  :: ZK              ! Above/Below canopy height, z (m)
-        REAL(RK),    INTENT( IN )  :: FAFRACK         ! Fractional (z) shapes of the
+        REAL(RK),    INTENT( IN )  :: HCM              ! Height of canopy top (m)
+        REAL(RK),    INTENT( IN )  :: ZK               ! Above/Below canopy height, z (m)
+        REAL(RK),    INTENT( IN )  :: FAFRACK          ! Fractional (z) shapes of the
         ! plant surface distribution (nondimensional)
-        REAL(RK),    INTENT( IN )  :: UBZREF          ! Mean wind speed at reference height (m/s)
-        REAL(RK),    INTENT( IN )  :: Z0GHC          ! Ratio of ground roughness length to canopy top height (nondimensional)
+        REAL(RK),    INTENT( IN )  :: UBZREF           ! Mean wind speed at reference height (m/s)
+        REAL(RK),    INTENT( IN )  :: Z0GHC            ! Ratio of ground roughness length to canopy top height (nondimensional)
         REAL(RK),    INTENT( IN )  :: LAMBDARS         ! Value representing influence of roughness sublayer (nondimensional)
-        REAL(RK),    INTENT( IN )  :: CDRAG           ! Drag coefficient (nondimensional)
-        REAL(RK),    INTENT( IN )  :: PAI             ! Total plant/foliage area index (nondimensional)
-        REAL(RK),    INTENT( IN )  :: HREF            ! Reference Height above canopy associated with ref wind speed  (m)
-        REAL(RK),    INTENT( IN )  :: D_H             ! Zero plane displacement heights (nondimensional)
-        REAL(RK),    INTENT( IN )  :: ZO_H            ! Surface (soil+veg) roughness lengths (nondimensional)
-!        REAL(RK),    INTENT( IN )  :: MOL             ! Model input Monin-Obukhov Length
-        INTEGER,     INTENT( IN )  :: RSL_OPT         ! RSL option used in model (default = 0, LAMBDARS effect only)
-        REAL(RK),    INTENT( OUT ) :: CANBOT_OUT      ! Canopy bottom wind reduction factor = canbot (nondimensional)
-        REAL(RK),    INTENT( OUT ) :: CANTOP_OUT      ! Canopy top wind reduction factor = cantop    (nondimensional)
-        REAL(RK),    INTENT( OUT ) :: CANWIND         ! Mean canopy wind speed at current z (m/s)
+        REAL(RK),    INTENT( IN )  :: CDRAG            ! Drag coefficient (nondimensional)
+        REAL(RK),    INTENT( IN )  :: PAI              ! Total plant/foliage area index (nondimensional)
+        REAL(RK),    INTENT( IN )  :: HREF             ! Reference Height above canopy associated with ref wind speed  (m)
+        REAL(RK),    INTENT( IN )  :: D_H              ! Zero plane displacement heights (nondimensional)
+        REAL(RK),    INTENT( IN )  :: ZO_H             ! Surface (soil+veg) roughness lengths (nondimensional)
+        REAL(RK),    INTENT( IN )  :: MOL              ! Model input Monin-Obukhov Length
+        INTEGER,     INTENT( IN )  :: RSL_OPT          ! RSL option used in model (default = 0, LAMBDARS effect only)
+        REAL(RK),    INTENT( OUT ) :: CANBOT_OUT       ! Canopy bottom wind reduction factor = canbot (nondimensional)
+        REAL(RK),    INTENT( OUT ) :: CANTOP_OUT       ! Canopy top wind reduction factor = cantop    (nondimensional)
+        REAL(RK),    INTENT( OUT ) :: CANWIND          ! Mean canopy wind speed at current z (m/s)
 !       Local variables
-        real(rk)                   :: ustrmod         ! Friction Velocity parameterization based on Massman 2017 (m/s)
-        real(rk)                   :: z0g             ! Ground roughness length based on z0g/HCCM ratio (m)
-        real(rk)                   :: zkhcm           ! Current zk/hcm ratio (nondimensional)
-        real(rk)                   :: cstress         ! Surface stress at/above canopy height (nondimensional)
-        real(rk)                   :: drag            ! Drag area index (i.e., wind speed attenuation) (nondimensional)
-        real(rk)                   :: nrat            ! Ratio of drag/cstress (nondimensional)
-        real(rk)                   :: canbot          ! Logarithmic wind speed that is dominant near the ground (nondimensional)
-        real(rk)                   :: cantop          ! Hyperbolic cosine wind speed that is dominant near the top of canopy (nondimensional)
-        real(rk)                   :: zpd             ! Zero plane displacement heights (m)
-        real(rk)                   :: z0m             ! Surface (soil+veg) roughness lengths (m)
-        real(rk)                   :: uc              ! Wind directly at canopy top (m/s)
-!        real(rk)                   :: beta, beta_n    ! Ratio of u* to wind speed at canopy height
-!        real(rk)                   :: beta1, beta2    ! Terms used in calculating beta above
-!        real(rk)                   :: can_length      ! Canopy length scale (= HCM/CDRAG*PAI)
+        real(rk)                   :: ustrmod          ! Friction Velocity parameterization based on Massman 2017 (m/s)
+        real(rk)                   :: z0g              ! Ground roughness length based on z0g/HCCM ratio (m)
+        real(rk)                   :: zkhcm            ! Current zk/hcm ratio (nondimensional)
+        real(rk)                   :: cstress          ! Surface stress at/above canopy height (nondimensional)
+        real(rk)                   :: drag             ! Drag area index (i.e., wind speed attenuation) (nondimensional)
+        real(rk)                   :: nrat             ! Ratio of drag/cstress (nondimensional)
+        real(rk)                   :: canbot           ! Logarithmic wind speed that is dominant near the ground (nondimensional)
+        real(rk)                   :: cantop           ! Hyperbolic cosine wind speed that is dominant near the top of canopy (nondimensional)
+        real(rk)                   :: zpd              ! Zero plane displacement heights MOST  (m)
+        real(rk)                   :: zpd_rsl          ! Zero plane displacement heights RSL   (m)
+        real(rk)                   :: z0m              ! Surface (soil+veg) roughness lengths with Massman LAMBDARS (m)
+        real(rk)                   :: uc               ! Wind directly at canopy top (m/s)
+        real(rk)                   :: cbeta            ! Term used to calculated beta_n for sparse canopies
+        real(rk)                   :: beta, beta_n     ! Ratio of u* to wind speed at canopy height
+        real(rk)                   :: beta1, beta2     ! Terms used in calculating beta above
+        real(rk)                   :: can_length       ! Canopy length scale (Lc= HCM/CDRAG*PAI) (m)
+        real(rk)                   :: mix_length       ! Mixing length scale (m)
+        real(rk)                   :: zref             ! Reference height above canopy top (m)
+        real(rk)                   :: phim, phim_rsl   ! Momentum terms used in for MOST and RSL adjustments
+        real(rk)                   :: c1, c2, xi       ! RSL terms used to adjust MOST for canopy-induced turbulence
+        real(rk)                   :: den1, den2, den3 !Denominator terms in RSL unified U* calculation
 
 ! Citation:
 ! An improved canopy wind model for predicting wind adjustment factors and wildland fire behavior
@@ -67,88 +74,135 @@ contains
         zkhcm = ZK/HCM
         z0g = Z0GHC*HCM
 
-        ! Nondimensional canopy wind speed term that dominates near the top of the canopy:
-        ! Assume the drag area distribution over depth of canopy can be approx. p1=0 (no shelter factor) and d1=0
-        ! (no drag coefficient relation to wind speed) -- thus no integration then required in Eq. (4) of Massman et al.
+! Nondimensional canopy wind speed term that dominates near the top of the canopy:
+! Assume the drag area distribution over depth of canopy can be approx. p1=0 (no shelter factor) and d1=0
+! (no drag coefficient relation to wind speed) -- thus no integration then required in Eq. (4) of Massman et al.
         drag    = CDRAG*PAI
 
         zpd = D_H*HCM  !zero-plane displacement height (not scaled to HCM)
         z0m = ZO_H*HCM !aerodynamic roughness length (not scaled to HCM)
 
-        !first adjust reference wind down to canopy top to get u* from Massman closure equations (necessary)
+!First adjust reference wind down to canopy top to get u* from Massman closure equations (necessary) or
+!from unified RSL approach.  This is needed to get accurate canopy stress terms for in-canopy winds later...
 
         if((HCM-zpd) <= 0.) then
             write(*,*) "critical problem: hcan <= zpd"
             call exit(1)
         end if
 
-        if (HREF > z0m) then ! input wind speed reference height is > roughness length
-            uc = UBZREF*log(LAMBDARS*(HCM-zpd+z0m)/z0m)/log(HREF/z0m)  !MOST From NoahMP (M. Barlarge) with user RSL influence term (LAMBDARS)
-        else                 ! reference height is <= roughness length--at canopy top (used for observation comparison)
-            uc = UBZREF
-        end if
+        if (RSL_OPT .eq. 0) then !Massman approach with MOST + LAMBDARS tuned RSL factor/effects
 
-        !Some checks on Uc calculation
-        if (uc > UBZREF) then !reference height too small and close to roughness length
-            uc = UBZREF
-        end if
+            if (HREF > z0m) then ! input wind speed reference height is > roughness length
+                uc = UBZREF*log(LAMBDARS*(HCM-zpd+z0m)/z0m)/log(HREF/z0m)  !MOST From NoahMP (M. Barlarge) with user RSL influence term (LAMBDARS)
+            else                 ! reference height is <= roughness length--at canopy top (used for observation comparison)
+                uc = UBZREF
+            end if
 
-        if (uc <= 0.0) then
-            write(*,*)  'Uc cannot be <= 0 at  ',uc , ' in canopy_wind calc...exiting'
-            call exit(1)
-        end if
+            !Some checks on Uc calculation
+            if (uc > UBZREF) then !reference height too small and close to roughness length
+                uc = UBZREF
+            end if
 
-        !calculate U* from Massman 1997 (https://doi.org/10.1023/A:1000234813011)
-        ustrmod = uc*(0.38_rk - (0.38_rk + (vonk/log(Z0GHC)))*exp(-1.0_rk*(15.0_rk*drag)))
+            if (uc <= 0.0) then
+                write(*,*)  'Uc cannot be <= 0 at  ',uc , ' in canopy_wind calc...exiting'
+                call exit(1)
+            end if
 
-!        if (HREF > z0m) then ! input wind speed reference height is > roughness length
-        if (RSL_OPT .ne. 0) then       !MOST From NoahMP (M. Barlarge) with user RSL influence term (LAMBDARS)
-!                uc = UBZREF*log(LAMBDARS*(HCM-zpd+z0m)/z0m)/log(HREF/z0m) !Recalculate Uc with LAMBDARS
-!            else if (RSL_OPT .eq. 1) then  !Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-!                beta_n = 0.35_rk               !beta for neutral conditions
-!                can_length = HCM/drag          !canopy length scale
-!
-!                !Check stability for β calculation
-!                IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
-!                    beta1 = -1.0_rk*((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)
-!                    beta2 = sqrt( (((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)**2.0_rk) + (4.0_rk*(beta_n**4.0_rk)) )
-!                    beta = sqrt( 0.5_rk * (beta1 + beta2) )
-!                ELSE IF ( MOL .GT.  0.0 ) THEN !STABLE to VERY STABLE
-!                    beta1 = -1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
-!                        4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
-!                        27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (1.0_rk/3.0_rk)) * &
-!                        (MOL/(15.0_rk*can_length))
-!                    beta2 = +1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
-!                        4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
-!                        27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (-1.0_rk/3.0_rk))
-!                    beta = (beta1 + beta2)
-!                ELSE                          !NEUTRAL
-!                    beta = beta_n
-!                END IF
-!
-!                !The solution for β is constrained between 0.2 and 0.5 (Bonan et al., 2018).
-!                if (beta .lt. 0.2) then
-!                    beta = 0.2
-!                else if (beta .gt. 0.5) then
-!                    beta = 0.5
-!                end if
-!
-!                uc = ustrmod/beta
-!            else
-            write(*,*) 'wrong namelist option = ', RSL_OPT, 'only option = 0 (MOST*LAMBDARS) is available right now'
+            !Calculate U* from Massman 1997 (https://doi.org/10.1023/A:1000234813011)
+            ustrmod = uc*(0.38_rk - (0.38_rk + (vonk/log(Z0GHC)))*exp(-1.0_rk*(15.0_rk*drag)))
+
+        else if (RSL_OPT .eq. 1) then  !Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
+            cbeta = vonk**2.0_rk*(log((HCM + 0.01_rk)/0.01_rk))**(-2.0_rk)
+            beta_n = (cbeta + (0.3_rk*PAI))**(0.5) !beta for neutral conditions
+            if (beta_n .gt. 0.35_rk) then      !constrained to be less than 0.35
+                beta_n = 0.35_rk
+            end if
+
+            can_length = HCM/drag          !canopy length scale (Lc)
+            zref = HREF + HCM              !reference height z above canopy top
+
+            !Check stability for β calculation
+            IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
+                beta1 = -1.0_rk*((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)
+                beta2 = sqrt( (((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)**2.0_rk) + (4.0_rk*(beta_n**4.0_rk)) )
+                beta = sqrt( 0.5_rk * (beta1 + beta2) )
+            ELSE IF ( MOL .GT.  0.0 ) THEN !STABLE to VERY STABLE
+                beta1 = -1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
+                    4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
+                    27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (1.0_rk/3.0_rk)) * &
+                    (MOL/(15.0_rk*can_length))
+                beta2 = +1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
+                    4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
+                    27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (-1.0_rk/3.0_rk))
+                beta = (beta1 + beta2)
+            ELSE                          !NEUTRAL
+                beta = beta_n
+            END IF
+
+            !Mixing length (lm)
+            mix_length=2.0_rk*(beta**(3.0_rk))*can_length
+            print*, 'mix_length=',mix_length
+
+            !The solution for β is constrained between 0.2 and 0.5 (Bonan et al., 2018).
+            if (beta .lt. 0.2) then
+                beta = 0.2
+            else if (beta .gt. 0.5) then
+                beta = 0.5
+            end if
+
+            !recalculate the zero plane displacement height for Unified RSL if dense or sparse canopy
+            !dense+sparse
+            zpd_rsl = HCM - ((beta**2.0_rk) * can_length) * &
+                (1.0_rk - exp(-1.0_rk*((0.25_rk*PAI)/(beta**2.0_rk))))
+
+            print*, 'can_length=',can_length, 'zpd=',zpd, 'zpd_rsl=',zpd_rsl
+            zpd_rsl=zpd
+
+            !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
+            IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
+                phim = (1.0_rk - (16.0_rk*((zref - zpd_rsl)/MOL)))**(-0.25_rk)
+            ELSE                           !NEUTRAL-STABLE
+                phim = (1.0_rk + (5.0_rk*((zref - zpd_rsl)/MOL)))
+            END IF
+
+            c2 = 0.5_rk
+            c1 = (1.0_rk - (vonk/(2.0_rk*beta))*(1.0_rk/phim)*((HCM - zpd_rsl)/MOL))*exp(c2/2.0_rk)
+            xi = ((zref - zpd_rsl)*beta)/mix_length
+            phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
+            den1 = (zref-zpd_rsl)/(HCM-zpd_rsl)
+            den2 = (zref-zpd_rsl)/MOL
+            den3 = (HCM-zpd_rsl)/MOL
+
+            ustrmod = (UBZREF*vonk)/(log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*zref) - (phim_rsl*HCM) +  &
+                (vonk/beta))
+            if (HREF > z0m) then ! input wind speed reference height is > roughness length
+                uc = ustrmod/beta ! (Rosenzweig et al., 2021)
+            else
+                uc = UBZREF
+            end if
+
+            !Some checks on Uc calculation
+            if (uc > UBZREF) then !reference height too small and close to roughness length
+                uc = UBZREF
+            end if
+
+            if (uc <= 0.0) then
+                write(*,*)  'Uc cannot be <= 0 at  ',uc , ' in canopy_wind calc...exiting'
+                call exit(1)
+            end if
+
+        else
+            write(*,*) 'wrong namelist option = ', RSL_OPT, 'only options = 0 or 1 is available right now'
             call exit(2)
         end if
-!        else
-!            uc = UBZREF
-!        end if
 
-        !Calculate in-canopy parameters that dominate near top region of canopy (Massman et al., 2017)
+!Calculate in-canopy parameters that dominate near top region of canopy (Massman et al., 2017)
         cstress = (2.0_rk*(ustrmod**2.0_rk))/(uc**2.0_rk)
         nrat   =  drag/cstress
         cantop = cosh(nrat*FAFRACK)/cosh(nrat)
         CANTOP_out = cantop
 
-        !Calculate in-canopy parameters that dominate near the ground:
+!Calculate in-canopy parameters that dominate near the ground:
         if (ZK >= z0g .and. ZK <= HCM) then
             canbot = log(zkhcm/Z0GHC)/log(1.0_rk/Z0GHC)
         else if (ZK >= 0 .and. ZK <= z0g) then
@@ -158,15 +212,45 @@ contains
         end if
         CANBOT_OUT = canbot
 
-        if (ZK <= HCM) then       !at or below canopy top --> in-canopy profile
+!Calculate the canopy wind variable both above and below canopy top
+
+        if (ZK <= HCM) then       !at or below canopy top --> Massman in-canopy profile
             CANWIND = uc*canbot*cantop
-        else                      !above canopy top       --> log profile
-            if (uc < UBZREF) then !reference height is not small compared to z0m
-                CANWIND = UBZREF*log(LAMBDARS*(ZK-zpd+z0m)/z0m)/log(HREF/z0m)
-            else                  !cannot calcualate above canopy wind, set constant to UBZREF
-                CANWIND = UBZREF
-            end if
-        end if
+        else                      !above canopy top       --> MOST or RSL profile
+            if (RSL_OPT .eq. 0) then
+                if (uc < UBZREF) then !reference height is not small compared to z0m
+                    CANWIND = UBZREF*log(LAMBDARS*(ZK-zpd+z0m)/z0m)/log(HREF/z0m)
+                else                  !cannot calcualate above canopy wind, set constant to UBZREF
+                    CANWIND = UBZREF
+                end if
+            else if (RSL_OPT .eq. 1) then
+                if (uc < UBZREF) then !reference height is not small compared to z0m
+                    !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
+                    IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
+                        phim = (1.0_rk - (16.0_rk*((ZK - zpd_rsl)/MOL)))**(-0.25_rk)
+                    ELSE                           !NEUTRAL-STABLE
+                        phim = (1.0_rk + (5.0_rk*((ZK - zpd_rsl)/MOL)))
+                    END IF
+
+                    c2 = 0.5_rk
+                    c1 = (1.0_rk - (vonk/(2.0_rk*beta))*(1.0_rk/phim)*((HCM - zpd_rsl)/MOL))*exp(c2/2.0_rk)
+                    xi = ((ZK - zpd_rsl)*beta)/mix_length
+                    phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
+                    den1 = (ZK-zpd_rsl)/(HCM-zpd_rsl)
+                    den2 = (ZK-zpd_rsl)/MOL
+                    den3 = (HCM-zpd_rsl)/MOL
+
+                    CANWIND = (ustrmod / vonk) * &
+                        (log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*den2) - (phim_rsl*den3) +  &
+                        (vonk/beta))
+                else                  !cannot calcualate above canopy wind, set constant to UBZREF
+                    CANWIND = UBZREF
+                end if
+            else
+                write(*,*) 'wrong namelist option = ', RSL_OPT, 'only options = 0 or 1 is available right now'
+                call exit(2)
+            end if !RSL Opt
+        end if !Above or below canopy
 
     END SUBROUTINE CANOPY_WIND
 

--- a/src/canopy_wind_mod.F90
+++ b/src/canopy_wind_mod.F90
@@ -112,8 +112,8 @@ contains
             ustrmod = uc*(0.38_rk - (0.38_rk + (vonk/log(Z0GHC)))*exp(-1.0_rk*(15.0_rk*drag)))
 
         else if (RSL_OPT .eq. 1) then  !Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-            cbeta = vonk**2.0_rk*(log((HCM + 0.01_rk)/0.01_rk))**(-2.0_rk)
-            beta_n = (cbeta + (0.3_rk*PAI))**(0.5) !beta for neutral conditions
+            cbeta = vonk**2.0_rk*(log((HCM + 0.01_rk)/0.01_rk))**(-2.0_rk) !dense and sparse canopies
+            beta_n = (cbeta + (0.3_rk*PAI))**(0.5) !beta for neutral conditions, dense and sparse canopies
             if (beta_n .gt. 0.35_rk) then      !constrained to be less than 0.35
                 beta_n = 0.35_rk
             end if
@@ -139,10 +139,6 @@ contains
                 beta = beta_n
             END IF
 
-            !Mixing length (lm)
-            mix_length=2.0_rk*(beta**(3.0_rk))*can_length
-            print*, 'mix_length=',mix_length
-
             !The solution for β is constrained between 0.2 and 0.5 (Bonan et al., 2018).
             if (beta .lt. 0.2) then
                 beta = 0.2
@@ -150,13 +146,17 @@ contains
                 beta = 0.5
             end if
 
-            !recalculate the zero plane displacement height for Unified RSL if dense or sparse canopy
-            !dense+sparse
+            !Mixing length (lm)
+            mix_length=2.0_rk*(beta**(3.0_rk))*can_length
+!            print*, 'mix_length=',mix_length
+
+!recalculate the zero plane displacement height for Unified RSL if dense or sparse canopy
+!dense+sparse
             zpd_rsl = HCM - ((beta**2.0_rk) * can_length) * &
                 (1.0_rk - exp(-1.0_rk*((0.25_rk*PAI)/(beta**2.0_rk))))
 
-            print*, 'can_length=',can_length, 'zpd=',zpd, 'zpd_rsl=',zpd_rsl
-            zpd_rsl=zpd
+!            print*, 'can_length=',can_length, 'zpd=',zpd, 'zpd_rsl=',zpd_rsl
+!            zpd_rsl=zpd
 
             !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
             IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
@@ -238,7 +238,9 @@ contains
                     phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
                     den1 = (ZK-zpd_rsl)/(HCM-zpd_rsl)
                     den2 = (ZK-zpd_rsl)/MOL
+!                    den2 = (ZK-zpd_rsl)/(mix_length*beta)
                     den3 = (HCM-zpd_rsl)/MOL
+!                    den3 = (HCM-zpd_rsl)/(mix_length*beta)
 
                     CANWIND = (ustrmod / vonk) * &
                         (log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*den2) - (phim_rsl*den3) +  &

--- a/src/canopy_wind_mod.F90
+++ b/src/canopy_wind_mod.F90
@@ -41,8 +41,6 @@ contains
         REAL(RK),    INTENT( IN )  :: HREF             ! Reference Height above canopy associated with ref wind speed  (m)
         REAL(RK),    INTENT( IN )  :: D_H              ! Zero plane displacement heights (nondimensional)
         REAL(RK),    INTENT( IN )  :: ZO_H             ! Surface (soil+veg) roughness lengths (nondimensional)
-!        REAL(RK),    INTENT( IN )  :: MOL              ! Model input Monin-Obukhov Length
-!        INTEGER,     INTENT( IN )  :: RSL_OPT          ! RSL option used in model (default = 0, LAMBDARS effect only)
         REAL(RK),    INTENT( OUT ) :: CANBOT_OUT       ! Canopy bottom wind reduction factor = canbot (nondimensional)
         REAL(RK),    INTENT( OUT ) :: CANTOP_OUT       ! Canopy top wind reduction factor = cantop    (nondimensional)
         REAL(RK),    INTENT( OUT ) :: CANWIND          ! Mean canopy wind speed at current z (m/s)
@@ -56,18 +54,8 @@ contains
         real(rk)                   :: canbot           ! Logarithmic wind speed that is dominant near the ground (nondimensional)
         real(rk)                   :: cantop           ! Hyperbolic cosine wind speed that is dominant near the top of canopy (nondimensional)
         real(rk)                   :: zpd              ! Zero plane displacement heights MOST  (m)
-!        real(rk)                   :: zpd_rsl          ! Zero plane displacement heights RSL   (m)
         real(rk)                   :: z0m              ! Surface (soil+veg) roughness lengths with Massman LAMBDARS (m)
         real(rk)                   :: uc               ! Wind directly at canopy top (m/s)
-!        real(rk)                   :: cbeta            ! Term used to calculated beta_n for sparse canopies
-!        real(rk)                   :: beta, beta_n     ! Ratio of u* to wind speed at canopy height
-!        real(rk)                   :: beta1, beta2     ! Terms used in calculating beta above
-!        real(rk)                   :: can_length       ! Canopy length scale (Lc= HCM/CDRAG*PAI) (m)
-!        real(rk)                   :: mix_length       ! Mixing length scale (m)
-!        real(rk)                   :: zref             ! Reference height above canopy top (m)
-!        real(rk)                   :: phim, phim_rsl   ! Momentum terms used in for MOST and RSL adjustments
-!        real(rk)                   :: c1, c2, xi       ! RSL terms used to adjust MOST for canopy-induced turbulence
-!        real(rk)                   :: den1, den2, den3 !Denominator terms in RSL unified U* calculation
 
 ! Citation:
 ! An improved canopy wind model for predicting wind adjustment factors and wildland fire behavior
@@ -112,91 +100,6 @@ contains
         !Calculate U* from Massman 1997 (https://doi.org/10.1023/A:1000234813011)
         ustrmod = uc*(0.38_rk - (0.38_rk + (vonk/log(Z0GHC)))*exp(-1.0_rk*(15.0_rk*drag)))
 
-!        else if (RSL_OPT .eq. 1) then  !Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-!            cbeta = vonk**2.0_rk*(log((HCM + 0.01_rk)/0.01_rk))**(-2.0_rk) !dense and sparse canopies
-!            beta_n = (cbeta + (0.3_rk*PAI))**(0.5) !beta for neutral conditions, dense and sparse canopies
-!            if (beta_n .gt. 0.35_rk) then      !constrained to be less than 0.35
-!                beta_n = 0.35_rk
-!            end if
-!
-!            can_length = HCM/drag          !canopy length scale (Lc)
-!            zref = HREF + HCM              !reference height z above canopy top
-!
-!            !Check stability for β calculation
-!            IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
-!                beta1 = -1.0_rk*((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)
-!                beta2 = sqrt( (((16.0_rk*(beta_n**4.0_rk)*can_length)/MOL)**2.0_rk) + (4.0_rk*(beta_n**4.0_rk)) )
-!                beta = sqrt( 0.5_rk * (beta1 + beta2) )
-!            ELSE IF ( MOL .GT.  0.0 ) THEN !STABLE to VERY STABLE
-!                beta1 = -1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
-!                    4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
-!                    27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (1.0_rk/3.0_rk)) * &
-!                    (MOL/(15.0_rk*can_length))
-!                beta2 = +1.0_rk * (( 0.5 * ( sqrt ((-27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk)**2.0_rk + &
-!                    4.0_rk*(15.0_rk*(can_length/MOL))**3.0_rk ) - &
-!                    27.0_rk*beta_n*((5.0_rk*can_length)/MOL)**2.0_rk )) ** (-1.0_rk/3.0_rk))
-!                beta = (beta1 + beta2)
-!            ELSE                          !NEUTRAL
-!                beta = beta_n
-!            END IF
-!
-!            !The solution for β is constrained between 0.2 and 0.5 (Bonan et al., 2018).
-!            if (beta .lt. 0.2) then
-!                beta = 0.2
-!            else if (beta .gt. 0.5) then
-!                beta = 0.5
-!            end if
-!
-!            !Mixing length (lm)
-!            mix_length=2.0_rk*(beta**(3.0_rk))*can_length
-!!            print*, 'mix_length=',mix_length
-!
-!!recalculate the zero plane displacement height for Unified RSL if dense or sparse canopy
-!!dense+sparse
-!            zpd_rsl = HCM - ((beta**2.0_rk) * can_length) * &
-!                (1.0_rk - exp(-1.0_rk*((0.25_rk*PAI)/(beta**2.0_rk))))
-!
-!!            print*, 'can_length=',can_length, 'zpd=',zpd, 'zpd_rsl=',zpd_rsl
-!!            zpd_rsl=zpd
-!
-!            !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-!            IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
-!                phim = (1.0_rk - (16.0_rk*((zref - zpd_rsl)/MOL)))**(-0.25_rk)
-!            ELSE                           !NEUTRAL-STABLE
-!                phim = (1.0_rk + (5.0_rk*((zref - zpd_rsl)/MOL)))
-!            END IF
-!
-!            c2 = 0.5_rk
-!            c1 = (1.0_rk - (vonk/(2.0_rk*beta))*(1.0_rk/phim)*((HCM - zpd_rsl)/MOL))*exp(c2/2.0_rk)
-!            xi = ((zref - zpd_rsl)*beta)/mix_length
-!            phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
-!            den1 = (zref-zpd_rsl)/(HCM-zpd_rsl)
-!            den2 = (zref-zpd_rsl)/MOL
-!            den3 = (HCM-zpd_rsl)/MOL
-!
-!            ustrmod = (UBZREF*vonk)/(log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*zref) - (phim_rsl*HCM) +  &
-!                (vonk/beta))
-!            if (HREF > z0m) then ! input wind speed reference height is > roughness length
-!                uc = ustrmod/beta ! (Rosenzweig et al., 2021)
-!            else
-!                uc = UBZREF
-!            end if
-!
-!            !Some checks on Uc calculation
-!            if (uc > UBZREF) then !reference height too small and close to roughness length
-!                uc = UBZREF
-!            end if
-!
-!            if (uc <= 0.0) then
-!                write(*,*)  'Uc cannot be <= 0 at  ',uc , ' in canopy_wind calc...exiting'
-!                call exit(1)
-!            end if
-!
-!        else
-!            write(*,*) 'wrong namelist option = ', RSL_OPT, 'only options = 0 or 1 is available right now'
-!            call exit(2)
-!        end if
-
 !Calculate in-canopy parameters that dominate near top region of canopy (Massman et al., 2017)
         cstress = (2.0_rk*(ustrmod**2.0_rk))/(uc**2.0_rk)
         nrat   =  drag/cstress
@@ -218,41 +121,11 @@ contains
         if (ZK <= HCM) then       !at or below canopy top --> Massman in-canopy profile
             CANWIND = uc*canbot*cantop
         else                      !above canopy top       --> MOST or RSL profile
-!            if (RSL_OPT .eq. 0) then
             if (uc < UBZREF) then !reference height is not small compared to z0m
                 CANWIND = UBZREF*log(LAMBDARS*(ZK-zpd+z0m)/z0m)/log(HREF/z0m)
             else                  !cannot calcualate above canopy wind, set constant to UBZREF
                 CANWIND = UBZREF
             end if
-!            else if (RSL_OPT .eq. 1) then
-!                if (uc < UBZREF) then !reference height is not small compared to z0m
-!                    !calculate U* from Unified RSL (Rosenzweig et al., 2021)  https://doi.org/10.1029/2021MS002665
-!                    IF ( MOL .LT.  0.0 )  THEN     !UNSTABLE
-!                        phim = (1.0_rk - (16.0_rk*((ZK - zpd_rsl)/MOL)))**(-0.25_rk)
-!                    ELSE                           !NEUTRAL-STABLE
-!                        phim = (1.0_rk + (5.0_rk*((ZK - zpd_rsl)/MOL)))
-!                    END IF
-!
-!                    c2 = 0.5_rk
-!                    c1 = (1.0_rk - (vonk/(2.0_rk*beta))*(1.0_rk/phim)*((HCM - zpd_rsl)/MOL))*exp(c2/2.0_rk)
-!                    xi = ((ZK - zpd_rsl)*beta)/mix_length
-!                    phim_rsl = 1.0_rk - c1*exp(-1.0_rk*c2*xi)
-!                    den1 = (ZK-zpd_rsl)/(HCM-zpd_rsl)
-!                    den2 = (ZK-zpd_rsl)/MOL
-!!                    den2 = (ZK-zpd_rsl)/(mix_length*beta)
-!                    den3 = (HCM-zpd_rsl)/MOL
-!!                    den3 = (HCM-zpd_rsl)/(mix_length*beta)
-!
-!                    CANWIND = (ustrmod / vonk) * &
-!                        (log(den1) - (phim*den2) + (phim*den3) + (phim_rsl*den2) - (phim_rsl*den3) +  &
-!                        (vonk/beta))
-!                else                  !cannot calcualate above canopy wind, set constant to UBZREF
-!                    CANWIND = UBZREF
-!                end if
-!            else
-!                write(*,*) 'wrong namelist option = ', RSL_OPT, 'only options = 0 or 1 is available right now'
-!                call exit(2)
-!            end if !RSL Opt
         end if !Above or below canopy
 
     END SUBROUTINE CANOPY_WIND_MOST


### PR DESCRIPTION
This addresses issue #56 , and instead of setting winds to reference height at z > hc, this uses the log wind profile above canopy top.  This also removes the fragmented RSL_OPT (=1) effects option that created even more discontinuity across the canopy top from the different approaches.  Thus, RSL_OPT = 0 is the only option for now, and uses the LAMBDARS scaling parameter to represent RSL effects above the canopy top for now.

After the change the wind speed profile is more continuous, with still a relatively sharp change at the canopy top from logarithmic to exponential in type.  
![image](https://user-images.githubusercontent.com/26631222/231643188-2f4b63b5-ff75-4803-a6c3-3c38b3a933bf.png)
