### PR TITLE
Modified Makefile to work with both ifort or gfortran to build canopy-app (Tested on Hera for ifort)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,21 @@ Compilation options can be controlled with environment variables:
 
 - `FC=gfortran` (default) or ifort
 - `DEBUG=0` (off; default) or `DEBUG=1` (on)
- - `NC=0` (off) or `NETCDF=1` (on; default)
+- `NC=0` (off) or `NETCDF=1` (on; default)
 
 Example:
 a) with gfortran, Debug flags ON and with Netcdf:
 ```
-DEBUG=1 NC=1 make -C src 
+DEBUG=1 NC=1 make -C src
 ```
 Note: Not supplying `FC` doesn't necessary give gfortran, since `FC` might already be set in the environment (such as, `module load` situations do this). On such case do:
 ```
-DEBUG=1 NC=1 FC=gfortran make -C src 
+DEBUG=1 NC=1 FC=gfortran make -C src
 ```
 b) with ifort, Debug flags ON and with Netcdf:
 ```
 DEBUG=1 NC=1 FC=ifort make -C src
-``` 
+```
 
 ### Modify settings
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Compilation options can be controlled with environment variables:
 
 - `FC=gfortran` (default) or ifort
 - `DEBUG=0` (off; default) or `DEBUG=1` (on)
-- `NC=0` (off) or `NETCDF=1` (on; default)
+- `NC=0` (off) or `NC=1` (on; default)
 
 Example:
 a) with compiler set by `FC` environment variable (falling back to `gfortran` if unset), Debug flags ON and with NetCDF:

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Compilation options can be controlled with environment variables:
 - `NC=0` (off) or `NETCDF=1` (on; default)
 
 Example:
-a) with gfortran, Debug flags ON and with Netcdf:
+a) with gfortran, Debug flags ON and with Netcdf (if `echo $FC` gives gfortran):
 ```
 DEBUG=1 NC=1 make -C src
 ```
-Note: Not supplying `FC` doesn't necessary give gfortran, since `FC` might already be set in the environment (such as, `module load` situations do this). On such case do:
+Note: Not supplying `FC` doesn't necessary give gfortran, since `FC` might already be set in the environment (such as, `module load` situations do this). In such case do:
 ```
 DEBUG=1 NC=1 FC=gfortran make -C src
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Compilation options can be controlled with environment variables:
 - `NC=0` (off) or `NETCDF=1` (on; default)
 
 Example:
-a) with gfortran, Debug flags ON and with Netcdf (if `echo $FC` gives gfortran):
+a) with compiler set by `FC` environment variable (falling back to `gfortran` if unset), Debug flags ON and with NetCDF:
 ```
 DEBUG=1 NC=1 make -C src
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ a) with compiler set by `FC` environment variable (falling back to `gfortran` if
 ```
 DEBUG=1 NC=1 make -C src
 ```
-Note: Not supplying `FC` doesn't necessary give gfortran, since `FC` might already be set in the environment (such as, `module load` situations do this). In such case do:
+Note: Not supplying `FC` doesn't necessarily give `gfortran`, since `FC` might already be set in the environment (for example, `module load` situations may do this). In such case do:
 ```
 DEBUG=1 NC=1 FC=gfortran make -C src
 ```

--- a/README.md
+++ b/README.md
@@ -19,13 +19,24 @@ Canopy-App requires NetCDF-Fortran Libraries (i.e., `-lnetcdf -lnetcdff`) when u
 See [the included Makefile](./src/Makefile), which detects NetCDF using `nf-config`, for an example (on GMU Hopper, you can use the `netcdf-c/4.7.4-vh` and `netcdf-fortran/4.5.3-ff` modules).
 
 Compilation options can be controlled with environment variables:
- - `DEBUG=0` (off; default) or `DEBUG=1` (on)
- - `NETCDF=0` (off) or `NETCDF=1` (on; default)
+
+- `FC=gfortran` (default) or ifort
+- `DEBUG=0` (off; default) or `DEBUG=1` (on)
+ - `NC=0` (off) or `NETCDF=1` (on; default)
 
 Example:
+a) with gfortran, Debug flags ON and with Netcdf:
 ```
-DEBUG=1 NETCDF=1 make -C src
+DEBUG=1 NC=1 make -C src 
 ```
+Note: Not supplying `FC` doesn't necessary give gfortran, since `FC` might already be set in the environment (such as, `module load` situations do this). On such case do:
+```
+DEBUG=1 NC=1 FC=gfortran make -C src 
+```
+b) with ifort, Debug flags ON and with Netcdf:
+```
+DEBUG=1 NC=1 FC=ifort make -C src
+``` 
 
 ### Modify settings
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note: Not supplying `FC` doesn't necessarily give `gfortran`, since `FC` might a
 ```
 DEBUG=1 NC=1 FC=gfortran make -C src
 ```
-b) with ifort, Debug flags ON and with Netcdf:
+b) with Intel Fortran (`ifort`), Debug flags ON and with NetCDF:
 ```
 DEBUG=1 NC=1 FC=ifort make -C src
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -47,7 +47,7 @@ ifeq ($(NC), 1)
 else ifeq ($(NC), 0)
   #
 else
-  $(error invalid setting for NETCDF, should be 0 or 1 but is '$(NC)')
+  $(error invalid setting for NC, should be 0 or 1 but is '$(NC)')
 endif
 $(info LIBS: '$(LIBS)')
 $(info INC:  '$(INC)')

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,8 +22,9 @@ ifeq ($(DEBUG), 1)
   ifeq ($(FC),gfortran)
     FCFLAGS := -g -Wall -Wextra -Wconversion -Og -pedantic -fcheck=bounds -fmax-errors=5 
   else ifeq ($(FC),ifort)
-    #FCFLAGS := -g -warn all -implicitnone -O1 -stand f90 -error-limit 5  #Equivalent to gfortran Debug flags, builds with warnings on Hera
-    FCFLAGS  := -g -warn all -check bounds -traceback #builds without warnings on Hera
+    # Both the following Debug flag options build Canopy-app on Hera with ifort without warnings 
+    #FCFLAGS := -g -warn all -implicitnone -O1 -stand f90 -error-limit 5  #Equivalent to gfortran Debug flags
+    FCFLAGS  := -g -warn all -check bounds -traceback 
   endif
 else ifeq ($(DEBUG), 0)
   FCFLAGS := -O3

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@
 # Compiler
 FC ?= gfortran
 ifeq ($(FC), f77)  # override possible Make default
-  FC := gfortran
+  FC := ifort
 endif
 $(info FC setting: '$(FC)')
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@
 # Compiler
 FC ?= gfortran
 ifeq ($(FC), f77)  # override possible Make default
-  FC := ifort
+  FC := gfortran
 endif
 $(info FC setting: '$(FC)')
 
@@ -22,9 +22,9 @@ ifeq ($(DEBUG), 1)
   ifeq ($(FC),gfortran)
     FCFLAGS := -g -Wall -Wextra -Wconversion -Og -pedantic -fcheck=bounds -fmax-errors=5 
   else ifeq ($(FC),ifort)
-    # Both the following Debug flag options build Canopy-app on Hera with ifort without warnings 
-    #FCFLAGS := -g -warn all -implicitnone -O1 -stand f90 -error-limit 5  #Equivalent to gfortran Debug flags
-    FCFLAGS  := -g -warn all -check bounds -traceback 
+    # Tested the following Debug flag options on Hera with 'DEBUG=1 NETCDF=1 FC=ifort make -C src'
+    #FCFLAGS := -g -warn all -implicitnone -O1 -stand f90 -error-limit 5  #Equivalent to gfortran Debug flags  #builds but with WARNINGS to be resolved 
+    FCFLAGS  := -g -warn all -check bounds -traceback  #builds Canopy-app on Hera with FC=ifort without warnings
   endif
 else ifeq ($(DEBUG), 0)
   FCFLAGS := -O3

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,7 @@ endif
 # NETCDF Settings here
 LIBS :=
 INC :=
-$(info NETCDF setting: '$(NC)')
+$(info NC setting: '$(NC)')
 ifeq ($(NC), 1)
   NETCDF_FLIBS := $(shell nf-config --flibs)
   NETCDF_INC := -I$(shell nf-config --includedir)

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,10 +22,7 @@ ifeq ($(DEBUG), 1)
   ifeq ($(FC),gfortran)
     FCFLAGS := -g -Wall -Wextra -Wconversion -Og -pedantic -fcheck=bounds -fmax-errors=5 -std=f2003 -fall-intrinsics
   else ifeq ($(FC),ifort)
-    # Tested the following Debug flag options on Hera with 'DEBUG=1 NC=1 FC=ifort make -C src'
-    # Both options build without warnings and also make clean in src
-    FCFLAGS := -g -warn all -implicitnone -O1 -error-limit 5  #Equivalent to gfortran Debug flags
-    #FCFLAGS  := -g -warn all -check bounds -traceback  #also builds Canopy-app on Hera with FC=ifort without warnings
+    FCFLAGS := -g -warn all -check bounds -implicitnone -O0 -error-limit 5
   endif
 else ifeq ($(DEBUG), 0)
   FCFLAGS := -O3

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,8 +6,6 @@
 # Compiler
 FC ?= gfortran
 ifeq ($(FC), f77)  # override possible Make default
-  FC := ifort 
-else ifeq ($(FC),gfortran)
   FC := gfortran
 endif
 $(info FC setting: '$(FC)')

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,6 @@
 # Use `FC=<compiler> ... make` to select compiler
 # Use `DEBUG=1 ... make` for a debug build
 # Use `NETCDF=1 ... make` to build with NetCDF using `nf-config`
-# compile with either FC=ifort or FC=gfortran
 
 # Compiler
 FC ?= gfortran

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,10 +2,13 @@
 # Use `FC=<compiler> ... make` to select compiler
 # Use `DEBUG=1 ... make` for a debug build
 # Use `NETCDF=1 ... make` to build with NetCDF using `nf-config`
+# compile with either FC=ifort or FC=gfortran
 
 # Compiler
 FC ?= gfortran
 ifeq ($(FC), f77)  # override possible Make default
+  FC := ifort 
+else ifeq ($(FC),gfortran)
   FC := gfortran
 endif
 $(info FC setting: '$(FC)')
@@ -19,7 +22,12 @@ NETCDF ?= 1
 # Compile flags
 $(info DEBUG setting: '$(DEBUG)')
 ifeq ($(DEBUG), 1)
-  FCFLAGS := -g -Wall -Wextra -Wconversion -Og -pedantic -fcheck=bounds -fmax-errors=5
+  ifeq ($(FC),gfortran)
+    FCFLAGS := -g -Wall -Wextra -Wconversion -Og -pedantic -fcheck=bounds -fmax-errors=5 
+  else ifeq ($(FC),ifort)
+    #FCFLAGS := -g -warn all -implicitnone -O1 -stand f90 -error-limit 5  #Equivalent to gfortran Debug flags, builds with warnings on Hera
+    FCFLAGS  := -g -warn all -check bounds -traceback #builds without warnings on Hera
+  endif
 else ifeq ($(DEBUG), 0)
   FCFLAGS := -O3
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 #
 # Use `FC=<compiler> ... make` to select compiler
 # Use `DEBUG=1 ... make` for a debug build
-# Use `NETCDF=1 ... make` to build with NetCDF using `nf-config`
+# Use `NC=1 ... make` to build with NetCDF using `nf-config`
 
 # Compiler
 FC ?= gfortran
@@ -14,17 +14,18 @@ $(info FC setting: '$(FC)')
 DEBUG ?= 0
 
 # Default to NetCDF build
-NETCDF ?= 1
+NC ?= 1
 
 # Compile flags
 $(info DEBUG setting: '$(DEBUG)')
 ifeq ($(DEBUG), 1)
   ifeq ($(FC),gfortran)
-    FCFLAGS := -g -Wall -Wextra -Wconversion -Og -pedantic -fcheck=bounds -fmax-errors=5 
+    FCFLAGS := -g -Wall -Wextra -Wconversion -Og -pedantic -fcheck=bounds -fmax-errors=5 -std=f2003 -fall-intrinsics
   else ifeq ($(FC),ifort)
-    # Tested the following Debug flag options on Hera with 'DEBUG=1 NETCDF=1 FC=ifort make -C src'
-    #FCFLAGS := -g -warn all -implicitnone -O1 -stand f90 -error-limit 5  #Equivalent to gfortran Debug flags  #builds but with WARNINGS to be resolved 
-    FCFLAGS  := -g -warn all -check bounds -traceback  #builds Canopy-app on Hera with FC=ifort without warnings
+    # Tested the following Debug flag options on Hera with 'DEBUG=1 NC=1 FC=ifort make -C src'
+    # Both options build without warnings and also make clean in src
+    FCFLAGS := -g -warn all -implicitnone -O1 -error-limit 5  #Equivalent to gfortran Debug flags
+    #FCFLAGS  := -g -warn all -check bounds -traceback  #also builds Canopy-app on Hera with FC=ifort without warnings
   endif
 else ifeq ($(DEBUG), 0)
   FCFLAGS := -O3
@@ -35,18 +36,18 @@ endif
 # NETCDF Settings here
 LIBS :=
 INC :=
-$(info NETCDF setting: '$(NETCDF)')
-ifeq ($(NETCDF), 1)
+$(info NETCDF setting: '$(NC)')
+ifeq ($(NC), 1)
   NETCDF_FLIBS := $(shell nf-config --flibs)
   NETCDF_INC := -I$(shell nf-config --includedir)
   #
   LIBS += $(NETCDF_FLIBS)
   INC += $(NETCDF_INC)
   FCFLAGS += -DNETCDF
-else ifeq ($(NETCDF), 0)
+else ifeq ($(NC), 0)
   #
 else
-  $(error invalid setting for NETCDF, should be 0 or 1 but is '$(NETCDF)')
+  $(error invalid setting for NETCDF, should be 0 or 1 but is '$(NC)')
 endif
 $(info LIBS: '$(LIBS)')
 $(info INC:  '$(INC)')
@@ -80,7 +81,7 @@ OBJS :=\
  canopy_dealloc.o \
  canopy_app.o
 
-ifeq ($(NETCDF), 0)
+ifeq ($(NC), 0)
   _ncf_objs := canopy_check_input.o canopy_ncf_io_mod.o
   OBJS := $(filter-out $(_ncf_objs),$(OBJS))
 endif


### PR DESCRIPTION
#FCFLAGS := -g -warn all -implicitnone -O1 -stand f90 -error-limit 5  #Equivalent to gfortran Debug flags, builds with warnings on Hera
    FCFLAGS  := -g -warn all -check bounds -traceback #builds without warnings on Hera

-stand flag works for different Fortran version (say for Fortran 2008, f90 can be replaced by f08)
Optimization flag can also be changed accordingly (-O1, -O2 etc.)