### PR TITLE
New WAI adaptation for PAI calculation option from Fang et al.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ You can also [generate global inputs using Python (see python/global_data_proces
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
 | `rsl_opt`       | user-set option for either MOST or unified Roughness SubLayer (RSL) effects above and at canopy top (Uc).(= `0`, default: uses MOST and a constant lambdars factor only), (= `1`, under development: will use a more unified RSL approach from Bonan et al. (2018) and Abolafia-Rosenzweig et al., 2021)   |
 | `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |
-| `pai_opt`       | integer (`0`: PAI fixed from Katul et al. 2004 veg types-->default; `1`: PAI Massman et al. 2017 Eq. 19 calc; `2`: PAI from model LAI+WAI; `3`: user-set PAI value) |
+| `pai_opt`       | integer (`0`: PAI fixed from Katul et al. 2004 veg types-->default; `1`: PAI Massman et al. 2017 Eq. 19 calc; `2`: PAI from model LAI (based on PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio" and is vegetation type dependent from Fang et al. (2019), https://doi.org/10.1029/2018RG000608; `3`: user-set PAI value) |
 | `pai_set`       | user-set real value of PAI (default: `4.0`; only used if `pai_opt=3`)              |
 | `z0_opt`        | integer (`0`: use model input or `1`: vegtype dependent z0 for first estimate)     |
 |                 | **Canopy fire/WAF-specific options**                                               |

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ You can also [generate global inputs using Python (see python/global_data_proces
 | `z0ghc`         | ratio of ground roughness length to canopy top height (Massman et al., 2017)       |
 | `rsl_opt`       | user-set option for either MOST or unified Roughness SubLayer (RSL) effects above and at canopy top (Uc).(= `0`, default: uses MOST and a constant lambdars factor only), (= `1`, under development: will use a more unified RSL approach from Bonan et al. (2018) and Abolafia-Rosenzweig et al., 2021)   |
 | `lambdars`      | Value representing influence of RSL effects (with `rsl_opt=0`) (Massman et al., 2017)          |
-| `pai_opt`       | integer (`0`: PAI fixed from Katul et al. 2004 veg types-->default; `1`: PAI Massman et al. 2017 Eq. 19 calc; `2`: PAI from model LAI (based on PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio" and is vegetation type dependent from Fang et al. (2019), https://doi.org/10.1029/2018RG000608; `3`: user-set PAI value) |
+| `pai_opt`       | integer (`0`: PAI fixed from Katul et al. 2004 veg types-->default; `1`: PAI Massman et al. 2017 Eq. 19 calc; `2`: PAI from model LAI (based on PAI=LAI/(1-alpha)*Omega, where alpha is the "woody-to-total area ratio" and is vegetation type dependent, and Omega is the observed clumping index.  Based on Fang et al. (2019) (https://doi.org/10.1029/2018RG000608) and Zou et al., 2009 (https://doi.org/10.1093/treephys/tpp042) ; `3`: user-set PAI value) |
 | `pai_set`       | user-set real value of PAI (default: `4.0`; only used if `pai_opt=3`)              |
 | `z0_opt`        | integer (`0`: use model input or `1`: vegtype dependent z0 for first estimate)     |
 |                 | **Canopy fire/WAF-specific options**                                               |

--- a/src/canopy_calcs.F90
+++ b/src/canopy_calcs.F90
@@ -134,7 +134,7 @@ SUBROUTINE canopy_calcs(nn)
 
 ! ... call canopy parameters to get canopy, fire info, and shape distribution parameters
 
-                            call canopy_parm(vtyperef, hcmref, ffracref, lairef, &
+                            call canopy_parm(cluref, vtyperef, hcmref, ffracref, lairef, &
                                 pai_opt, pai_set, lu_opt, firetype, cdrag, &
                                 pai, zcanmax, sigmau, sigma1)
 
@@ -488,7 +488,7 @@ SUBROUTINE canopy_calcs(nn)
 
 ! ... call canopy parameters to get canopy, fire info, and shape distribution parameters
 
-                        call canopy_parm(vtyperef, hcmref, ffracref, lairef, &
+                        call canopy_parm(cluref, vtyperef, hcmref, ffracref, lairef, &
                             pai_opt, pai_set, lu_opt, firetype, cdrag, &
                             pai, zcanmax, sigmau, sigma1)
 

--- a/src/canopy_profile_mod.F90
+++ b/src/canopy_profile_mod.F90
@@ -5,7 +5,7 @@ module canopy_profile_mod
 contains
 
 !:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-    SUBROUTINE CANOPY_PARM( VTYPE, FCH, FFRAC, LAI, &
+    SUBROUTINE CANOPY_PARM( CLU, VTYPE, FCH, FFRAC, LAI, &
         PAI_OPT, PAI_SET, LU_OPT, FIRETYPE, CDRAG, &
         PAI, ZCANMAX, SIGMAU, SIGMA1 )
 
@@ -30,6 +30,7 @@ contains
 
 ! Arguments:
 !     IN/OUT
+        REAL(RK),    INTENT( IN )  :: CLU             ! Grid cell clumping index
         INTEGER,     INTENT( IN )  :: VTYPE           ! Grid cell dominant vegetation type
         REAL(RK),    INTENT( IN )  :: FCH             ! Grid cell canopy height (m)
         REAL(RK),    INTENT( IN )  :: FFRAC           ! Grid cell forest fraction
@@ -56,10 +57,10 @@ contains
                     PAI=(3.28_rk + 2.41_rk + 2.14_rk + 3.78_rk)/4.0_rk
                 else if (PAI_OPT .eq. 1) then !PAI calculation (Massman et al., Eq. 19)
                     PAI=CalcPAI(FCH,FFRAC)
-                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio"
+                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha)*CLU, where alpha is the "woody-to-total area ratio"
                     !and is vegetation type dependent from Fang et al. (2019),
                     !https://doi.org/10.1029/2018RG000608:
-                    PAI=LAI/(1.0_rk - 0.2_rk) !Assume evergreen are more boreal/conifer softwoods
+                    PAI=(LAI/(1.0_rk - 0.2_rk))*CLU !Assume alpha evergreen are more boreal/conifer softwoods
                 else if (PAI_OPT .eq. 3) then !PAI value from user
                     PAI=PAI_SET
                 else
@@ -79,10 +80,10 @@ contains
                     PAI=(4.93_rk + 3.28)/2.0_rk
                 else if (PAI_OPT .eq. 1) then !Massman PAI calculation (Eq. 19)
                     PAI=CalcPAI(FCH,FFRAC)
-                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio"
+                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha)*CLU, where alpha is the "woody-to-total area ratio"
                     !and is vegetation type dependent from Fang et al. (2019),
                     !https://doi.org/10.1029/2018RG000608:
-                    PAI=LAI/(1.0_rk - 0.1_rk) !assume deciduous have more tropical hardwoods
+                    PAI=(LAI/(1.0_rk - 0.1_rk))*CLU !assume alpha deciduous have more tropical hardwoods
                 else if (PAI_OPT .eq. 3) then !PAI value from user
                     PAI=PAI_SET
                 else
@@ -102,10 +103,10 @@ contains
                     PAI=(5.73_rk + 3.28_rk + 2.41_rk + 2.14_rk + 3.78_rk + 4.93_rk)/6.0_rk
                 else if (PAI_OPT .eq. 1) then !PAI calculation (Massman et al., Eq. 19)
                     PAI=CalcPAI(FCH,FFRAC)
-                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio"
+                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha)*CLU, where alpha is the "woody-to-total area ratio"
                     !and is vegetation type dependent from Fang et al. (2019),
                     !https://doi.org/10.1029/2018RG000608:
-                    PAI=LAI/(1.0_rk - 0.15_rk)!assume avg. of evergreen and deciduous
+                    PAI=(LAI/(1.0_rk - 0.15_rk))*CLU!assume alpha is avg. of evergreen and deciduous
                 else if (PAI_OPT .eq. 3) then !PAI value from user
                     PAI=PAI_SET
                 else
@@ -125,10 +126,10 @@ contains
                     PAI=(2.94_rk + 3.10_rk)/2.0_rk
                 else if (PAI_OPT .eq. 1) then !PAI calculation (Massman et al., Eq. 19)
                     PAI=CalcPAI(FCH,FFRAC)
-                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio"
+                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha)*CLU, where alpha is the "woody-to-total area ratio"
                     !and is vegetation type dependent from Fang et al. (2019),
                     !https://doi.org/10.1029/2018RG000608:
-                    PAI=LAI/(1.0_rk - 0.32_rk)!assume avg. of shrubs + savanna
+                    PAI=(LAI/(1.0_rk - 0.32_rk))*CLU!assume alpha is avg. of shrubs + savanna
                 else if (PAI_OPT .eq. 3) then !PAI value from user
                     PAI=PAI_SET
                 else

--- a/src/canopy_profile_mod.F90
+++ b/src/canopy_profile_mod.F90
@@ -56,10 +56,10 @@ contains
                     PAI=(3.28_rk + 2.41_rk + 2.14_rk + 3.78_rk)/4.0_rk
                 else if (PAI_OPT .eq. 1) then !PAI calculation (Massman et al., Eq. 19)
                     PAI=CalcPAI(FCH,FFRAC)
-                else if (PAI_OPT .eq. 2) then !PAI = LAI + SAI (WAI)
-                    PAI=LAI + 0.52_rk  !WAI  = 0.52 from Toda and Richardson (2018):
-                    ! https://doi.org/10.1016/j.agrformet.2017.09.004
-                    ! Section 3.3
+                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio"
+                    !and is vegetation type dependent from Fang et al. (2019),
+                    !https://doi.org/10.1029/2018RG000608:
+                    PAI=LAI/(1.0_rk - 0.2_rk) !Assume evergreen are more boreal/conifer softwoods
                 else if (PAI_OPT .eq. 3) then !PAI value from user
                     PAI=PAI_SET
                 else
@@ -79,10 +79,10 @@ contains
                     PAI=(4.93_rk + 3.28)/2.0_rk
                 else if (PAI_OPT .eq. 1) then !Massman PAI calculation (Eq. 19)
                     PAI=CalcPAI(FCH,FFRAC)
-                else if (PAI_OPT .eq. 2) then !need PAI function of model LAI
-                    PAI=LAI + 0.52_rk  !WAI  = 0.52 from Toda and Richardson (2018):
-                    !https://doi.org/10.1016/j.agrformet.2017.09.004
-                    ! Section 3.3
+                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio"
+                    !and is vegetation type dependent from Fang et al. (2019),
+                    !https://doi.org/10.1029/2018RG000608:
+                    PAI=LAI/(1.0_rk - 0.1_rk) !assume deciduous have more tropical hardwoods
                 else if (PAI_OPT .eq. 3) then !PAI value from user
                     PAI=PAI_SET
                 else
@@ -102,10 +102,10 @@ contains
                     PAI=(5.73_rk + 3.28_rk + 2.41_rk + 2.14_rk + 3.78_rk + 4.93_rk)/6.0_rk
                 else if (PAI_OPT .eq. 1) then !PAI calculation (Massman et al., Eq. 19)
                     PAI=CalcPAI(FCH,FFRAC)
-                else if (PAI_OPT .eq. 2) then !PAI = LAI + SAI (WAI)
-                    PAI=LAI + 0.52_rk  !WAI  = 0.52 from Toda and Richardson (2018):
-                    ! https://doi.org/10.1016/j.agrformet.2017.09.004
-                    ! Section 3.3
+                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio"
+                    !and is vegetation type dependent from Fang et al. (2019),
+                    !https://doi.org/10.1029/2018RG000608:
+                    PAI=LAI/(1.0_rk - 0.15_rk)!assume avg. of evergreen and deciduous
                 else if (PAI_OPT .eq. 3) then !PAI value from user
                     PAI=PAI_SET
                 else
@@ -125,10 +125,10 @@ contains
                     PAI=(2.94_rk + 3.10_rk)/2.0_rk
                 else if (PAI_OPT .eq. 1) then !PAI calculation (Massman et al., Eq. 19)
                     PAI=CalcPAI(FCH,FFRAC)
-                else if (PAI_OPT .eq. 2) then !PAI = LAI + SAI (WAI)
-                    PAI=LAI + 0.52_rk  !WAI  = 0.52 from Toda and Richardson (2018):
-                    !https://doi.org/10.1016/j.agrformet.2017.09.004
-                    ! Section 3.3
+                else if (PAI_OPT .eq. 2) then !PAI=LAI/(1-alpha), where alpha is the "woody-to-total area ratio"
+                    !and is vegetation type dependent from Fang et al. (2019),
+                    !https://doi.org/10.1029/2018RG000608:
+                    PAI=LAI/(1.0_rk - 0.32_rk)!assume avg. of shrubs + savanna
                 else if (PAI_OPT .eq. 3) then !PAI value from user
                     PAI=PAI_SET
                 else
@@ -207,6 +207,7 @@ contains
                 fainc(i) = exp((-1.0*((ZCANMAX-ZHC(i))**2.0))/SIGMA1**2.0)
             end if
         end do
+
         fatot = IntegrateTrapezoid(ZHC,fainc)
 
 ! ... calculate plant distribution function


### PR DESCRIPTION
@angehung5  This is the adaption of the WAI contribution using alpha (woody-to-total area ratio) for the PAI calculation option, PAI = LAI (1 - alpha), which is vegetation type dependent now.

This is based on Figure 1 of Fang et al., 2019:  https://doi.org/10.1029/2018RG000608