### PR TITLE
Changing to individual time step outputs for NetCDF files.

### DIFF
--- a/input/namelist.canopy
+++ b/input/namelist.canopy
@@ -3,13 +3,13 @@
 ! Recommend set file_out prefix to initial 'YYYY-MM-DD-HH-MMSS_region_identifier'
   file_vars    = 'input/gfs.t12z.20220630.sfcf023.canopy.nc' 'input/gfs.t12z.20220701.sfcf000.canopy.nc' 'input/gfs.t12z.20220701.sfcf001.canopy.nc'
 !  file_vars    = 'input/gfs.t12z.20220630.sfcf023.canopy.txt' 'input/gfs.t12z.20220701.sfcf000.canopy.txt' 'input/gfs.t12z.20220701.sfcf001.canopy.txt'
-  file_out     = 'output/2022-07-01-11-0000_southeast_us'
+  file_out     = 'output/southeast_us'
 
 !Single Point Example
 ! Recommend set file_out prefix to initial 'YYYY-MM-DD-HH-MMSS_point_identifier'
 !   file_vars    = 'input/point_file_20220630.sfcf023.txt' 'input/point_file_20220701.sfcf000.txt' 'input/point_file_20220701.sfcf001.txt'
 !   file_canvars  = 'input/point_file_canvars_20220630.sfcf023.txt' 'input/point_file_canvars_20220701.sfcf000.txt' 'input/point_file_canvars_20220701.sfcf001.txt'
-!   file_out     = 'output/2022-07-01-11-0000_point'
+!   file_out     = 'output/point'
 /
 
 &USERDEFS

--- a/src/canopy_app.F90
+++ b/src/canopy_app.F90
@@ -107,7 +107,14 @@ program canopy_app
 
 #ifdef NETCDF
         !only output if 2D input NCF is used
-        call canopy_write_ncf(trim(file_out(1)))
+!        call canopy_write_ncf(trim(file_out(1)))
+        if (nn.lt.10) then
+            call canopy_write_ncf(trim(file_out(1)) // '_t00' // ADJUSTL(nn_string))
+        else if (nn.ge.10.and.nn.lt.100) then
+            call canopy_write_ncf(trim(file_out(1)) // '_t0' // ADJUSTL(nn_string))
+        else
+            call canopy_write_ncf(trim(file_out(1)) // '_t' // ADJUSTL(nn_string))
+        end if
 #endif
 
 ! Update new date and time

--- a/src/canopy_app.F90
+++ b/src/canopy_app.F90
@@ -20,8 +20,10 @@ program canopy_app
 
     CHARACTER(LEN=24)                 :: time_next  ! YYYY-MM-DD-HH:MM:SS.SSSS
     CHARACTER(LEN=24)                 :: time_now   ! YYYY-MM-DD-HH:MM:SS.SSSS
-    integer   :: nn
-    CHARACTER(LEN=24)                 :: nn_string
+    CHARACTER(LEN=24)                 :: time_now_file
+
+    integer   :: n,nn
+!    CHARACTER(LEN=24)                 :: nn_string
 !-------------------------------------------------------------------------------
 ! Error, warning, and informational messages.
 !-------------------------------------------------------------------------------
@@ -92,29 +94,40 @@ program canopy_app
 !-------------------------------------------------------------------------------
 ! Write model output of canopy model calculations.
 !-------------------------------------------------------------------------------
-        write(nn_string,*) nn-1
-!        call canopy_write_txt(trim(file_out(1)) // '_' // trim(time_now))
-        if (nn.lt.10) then
-            call canopy_write_txt((trim(file_out(1)) // '_t00' // ADJUSTL(nn_string)), &
-                time_now)
-        else if (nn.ge.10.and.nn.lt.100) then
-            call canopy_write_txt((trim(file_out(1)) // '_t0' // ADJUSTL(nn_string)), &
-                time_now)
-        else
-            call canopy_write_txt((trim(file_out(1)) // '_t' // ADJUSTL(nn_string)), &
-                time_now)
-        end if
+!        write(nn_string,*) nn-1
+
+        time_now_file=time_now
+        do n = 1, len(time_now_file)
+            if (time_now_file(n:n) == ':') then
+                time_now_file(n:n) = '-'
+            end if
+        end do
+
+        call canopy_write_txt((trim(file_out(1)) // '_' // trim(time_now_file)),time_now)
+
+!        if (nn.lt.10) then
+!            call canopy_write_txt((trim(file_out(1)) // '_t00' // ADJUSTL(nn_string)), &
+!                time_now)
+!        else if (nn.ge.10.and.nn.lt.100) then
+!            call canopy_write_txt((trim(file_out(1)) // '_t0' // ADJUSTL(nn_string)), &
+!                time_now)
+!        else
+!            call canopy_write_txt((trim(file_out(1)) // '_t' // ADJUSTL(nn_string)), &
+!                time_now)
+!        end if
 
 #ifdef NETCDF
         !only output if 2D input NCF is used
+        call canopy_write_ncf(trim(file_out(1)) // '_' // ADJUSTL(time_now_file))
+
 !        call canopy_write_ncf(trim(file_out(1)))
-        if (nn.lt.10) then
-            call canopy_write_ncf(trim(file_out(1)) // '_t00' // ADJUSTL(nn_string))
-        else if (nn.ge.10.and.nn.lt.100) then
-            call canopy_write_ncf(trim(file_out(1)) // '_t0' // ADJUSTL(nn_string))
-        else
-            call canopy_write_ncf(trim(file_out(1)) // '_t' // ADJUSTL(nn_string))
-        end if
+!        if (nn.lt.10) then
+!            call canopy_write_ncf(trim(file_out(1)) // '_t00' // ADJUSTL(nn_string))
+!        else if (nn.ge.10.and.nn.lt.100) then
+!            call canopy_write_ncf(trim(file_out(1)) // '_t0' // ADJUSTL(nn_string))
+!        else
+!            call canopy_write_ncf(trim(file_out(1)) // '_t' // ADJUSTL(nn_string))
+!        end if
 #endif
 
 ! Update new date and time


### PR DESCRIPTION
@MaggieMarvin To avoid outputting to an overly large NetCDF output file in canopy-app, I decided to just change it to similarly how the text files work.  Now, here by default, canopy-app will output separate NetCDF files for each timestep (e.g., hourly) with the output timestep stamp on the filenames.   Its not the prettiest right now, but this should further facilitate testing longer biogenic simulations instead of having a single huge file.  Please have a close look and make sure the outputs look good.