### PR TITLE
Include wetland vtype with grasslands for biogenic parameter assignment

### DIFF
--- a/src/canopy_bioparm_mod.F90
+++ b/src/canopy_bioparm_mod.F90
@@ -1579,7 +1579,7 @@ contains
                 ROOTA = (6.326_rk + 7.718_rk)/2.0_rk
                 ROOTB = (1.567_rk + 1.262_rk)/2.0_rk
 
-            else if (VTYPE .ge. 8 .and. VTYPE .le. 10) then !VIIRS/MODIS Cat 8-10 Savannas and Grasslands
+            else if (VTYPE .ge. 8 .and. VTYPE .le. 11) then !VIIRS/MODIS Cat 8-10 Savannas and Grasslands
                 !--> Avearge Arctic C3 Grass, Cool C3 Grass, Warm C4 Grass)
 
                 EF = (EF12+EF13+EF14)/3.0_rk


### PR DESCRIPTION
I noticed this bug when running the gridded set up with DEBUG = 2: the model was crashing with a floating-point exception error traced back to undefined values for ROOTA and ROOTB for vegetation type 11 (wetlands). A closer look at the code showed that EF was also not defined for this vtype and was instead being set to zero in the else statement of the same if else structure.

Since we do expect some biogenic emissions from wetlands, we addressed these issues by lumping wetlands in with grasslands and assigning the same values for biogenic parameters EF, ROOTA, and ROOTB. With this fix under the same model set up the simulation completes successfully with no crash.