### PR TITLE
Group Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/" # .github/workflows
     schedule:
       interval: "monthly"
+    groups:
+      gha-workflow-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/update-modulefiles.yml
+++ b/.github/workflows/update-modulefiles.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Clone ufs-weather-model and copy modulefiles
       run: |
         git clone https://github.com/ufs-community/ufs-weather-model.git
+        mkdir -p modulefiles/
         cp -r ufs-weather-model/modulefiles/* modulefiles/
         rm -rf ufs-weather-model
 


### PR DESCRIPTION
should've done this in #170 to avoid the PR flurry. example: https://github.com/noaa-oar-arl/NEXUS/pull/102